### PR TITLE
feat: Scoped path for homeassistant frontend

### DIFF
--- a/build-scripts/webpack.js
+++ b/build-scripts/webpack.js
@@ -2,6 +2,7 @@
 const webpack = require("webpack");
 const path = require("path");
 const TerserPlugin = require("terser-webpack-plugin");
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const { WebpackManifestPlugin } = require("webpack-manifest-plugin");
 const log = require("fancy-log");
 const WebpackBar = require("webpackbar");
@@ -144,6 +145,10 @@ const createWebpackConfig = ({
         "@lit-labs/virtualizer/layouts/grid":
           "@lit-labs/virtualizer/layouts/grid.js",
       },
+      plugins: [new TsconfigPathsPlugin({ 
+        configFile: 'tsconfig.json',
+        extensions: [".ts", ".tsx", ".js", ".json"],
+      })],
     },
     output: {
       filename: ({ chunk }) => {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "@polymer/polymer": "patch:@polymer/polymer@3.4.1#./homeassistant-frontend/.yarn/patches/@polymer/polymer/pr-5569.patch"
   },
   "dependenciesOverride": {},
+  "devDependenciesOverride": {
+    "tsconfig-paths-webpack-plugin": "^4.0.1"
+  },
   "dependencies": {
     "@braintree/sanitize-url": "6.0.2",
     "@codemirror/autocomplete": "6.4.2",
@@ -241,6 +244,7 @@
     "tar": "6.1.13",
     "terser-webpack-plugin": "5.3.6",
     "ts-lit-plugin": "1.2.1",
+    "tsconfig-paths-webpack-plugin": "^4.0.1",
     "typescript": "4.9.5",
     "vinyl-buffer": "1.0.1",
     "vinyl-source-stream": "2.0.0",

--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -1,7 +1,7 @@
 // Compat needs to be first import
-import "../homeassistant-frontend/src/resources/compatibility";
-import "../homeassistant-frontend/src/resources/roboto";
-import "../homeassistant-frontend/src/resources/safari-14-attachshadow-patch";
+import "@ha/resources/compatibility";
+import "@ha/resources/roboto";
+import "@ha/resources/safari-14-attachshadow-patch";
 import "./main";
 
 const styleEl = document.createElement("style");

--- a/src/knx-router.ts
+++ b/src/knx-router.ts
@@ -2,8 +2,8 @@ import { customElement, property, state } from "lit/decorators";
 import {
   HassRouterPage,
   RouterOptions,
-} from "../homeassistant-frontend/src/layouts/hass-router-page";
-import { HomeAssistant, Route } from "../homeassistant-frontend/src/types";
+} from "@ha/layouts/hass-router-page";
+import { HomeAssistant, Route } from "@ha/types";
 import { KNX } from "./types/knx";
 
 @customElement("knx-router")

--- a/src/knx.ts
+++ b/src/knx.ts
@@ -1,8 +1,8 @@
 import { LitElement } from "lit";
 import { property } from "lit/decorators";
-import { getConfigEntries } from "../homeassistant-frontend/src/data/config_entries";
-import { ProvideHassLitMixin } from "../homeassistant-frontend/src/mixins/provide-hass-lit-mixin";
-import { HomeAssistant } from "../homeassistant-frontend/src/types";
+import { getConfigEntries } from "@ha/data/config_entries";
+import { ProvideHassLitMixin } from "@ha/mixins/provide-hass-lit-mixin";
+import { HomeAssistant } from "@ha/types";
 import { localize } from "./localize/localize";
 import { KNXLogger } from "./tools/knx-logger";
 import { KNX } from "./types/knx";

--- a/src/knx_ui.ts
+++ b/src/knx_ui.ts
@@ -5,7 +5,7 @@ import { KNXOverview } from "@views/overview";
 import { HomeAssistant, navigate } from "custom-card-helpers";
 import { css, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
-import { HaAppLayout } from "../homeassistant-frontend/src/layouts/ha-app-layout";
+import { HaAppLayout } from "@ha/layouts/ha-app-layout";
 
 @customElement("knx-custom-panel")
 export class KNXCustomPanel extends LitElement {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,19 +5,19 @@
 // import "@material/mwc-fab";
 import {css, html, TemplateResult} from "lit";
 import { customElement, property } from "lit/decorators";
-import { applyThemesOnElement } from "../homeassistant-frontend/src/common/dom/apply_themes_on_element";
-import { navigate } from "../homeassistant-frontend/src/common/navigate";
-import { makeDialogManager } from "../homeassistant-frontend/src/dialogs/make-dialog-manager";
-import "../homeassistant-frontend/src/resources/ha-style";
-import "../homeassistant-frontend/src/components/ha-tabs";
-import "../homeassistant-frontend/src/components/ha-menu-button";
-import "../homeassistant-frontend/src/layouts/ha-app-layout";
-import "../homeassistant-frontend/src/layouts/hass-subpage";
-import { HomeAssistant, Route } from "../homeassistant-frontend/src/types";
+import { applyThemesOnElement } from "@ha/common/dom/apply_themes_on_element";
+import { navigate } from "@ha/common/navigate";
+import { makeDialogManager } from "@ha/dialogs/make-dialog-manager";
+import "@ha/resources/ha-style";
+import "@ha/components/ha-tabs";
+import "@ha/components/ha-menu-button";
+import "@ha/layouts/ha-app-layout";
+import "@ha/layouts/hass-subpage";
+import { HomeAssistant, Route } from "@ha/types";
 import { knxElement } from "./knx";
 import "./knx-router";
 import { LocationChangedEvent } from "./types/navigation";
-import {haStyle} from "../homeassistant-frontend/src/resources/styles";
+import {haStyle} from "@ha/resources/styles";
 
 @customElement("knx-frontend")
 class KnxFrontend extends knxElement {

--- a/src/services/websocket.service.ts
+++ b/src/services/websocket.service.ts
@@ -1,4 +1,4 @@
-import { HomeAssistant } from "../../homeassistant-frontend/src/types";
+import { HomeAssistant } from "@ha/types";
 import { KNXInfo, KNXTelegram } from "../types/websocket";
 
 export const getKnxInfo = (hass: HomeAssistant): Promise<KNXInfo> =>

--- a/src/types/knx.ts
+++ b/src/types/knx.ts
@@ -1,4 +1,4 @@
-import { ConfigEntry } from "../../homeassistant-frontend/src/data/config_entries";
+import { ConfigEntry } from "@ha/data/config_entries";
 
 export interface KNX {
   language: string;

--- a/src/views/bus_monitor.ts
+++ b/src/views/bus_monitor.ts
@@ -5,18 +5,18 @@
 // import "@polymer/app-layout/app-toolbar/app-toolbar";
 import { css, html, CSSResultGroup, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { computeRTLDirection } from "../../homeassistant-frontend/src/common/util/compute_rtl";
-import "../../homeassistant-frontend/src/components/data-table/ha-data-table";
-import {
+import { computeRTLDirection } from "@ha/common/util/compute_rtl";
+import "@ha/components/data-table/ha-data-table";
+import type {
   DataTableColumnContainer,
   DataTableRowData,
-} from "../../homeassistant-frontend/src/components/data-table/ha-data-table";
-import "../../homeassistant-frontend/src/components/ha-button-menu";
-import "../../homeassistant-frontend/src/components/ha-card";
-import "../../homeassistant-frontend/src/layouts/ha-app-layout";
-import "../../homeassistant-frontend/src/layouts/hass-subpage";
-import { haStyle } from "../../homeassistant-frontend/src/resources/styles";
-import { HomeAssistant } from "../../homeassistant-frontend/src/types";
+} from "@ha/components/data-table/ha-data-table";
+import "@ha/components/ha-button-menu";
+import "@ha/components/ha-card";
+import "@ha/layouts/ha-app-layout";
+import "@ha/layouts/hass-subpage";
+import { haStyle } from "@ha/resources/styles";
+import { HomeAssistant } from "@ha/types";
 import { subscribeKnxTelegrams } from "../services/websocket.service";
 import { KNXTelegram } from "../types/websocket";
 

--- a/src/views/overview.ts
+++ b/src/views/overview.ts
@@ -1,10 +1,10 @@
 import { css, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import "../../homeassistant-frontend/src/components/ha-button-menu";
-import "../../homeassistant-frontend/src/components/ha-card";
-import "../../homeassistant-frontend/src/layouts/ha-app-layout";
-import "../../homeassistant-frontend/src/layouts/hass-subpage";
-import { HomeAssistant } from "../../homeassistant-frontend/src/types";
+import "@ha/components/ha-button-menu";
+import "@ha/components/ha-card";
+import "@ha/layouts/ha-app-layout";
+import "@ha/layouts/hass-subpage";
+import { HomeAssistant } from "@ha/types";
 import { getKnxInfo } from "../services/websocket.service";
 import { KNXInfo } from "../types/websocket";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,10 @@
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "baseUrl": "src",
+    "paths": {
+      "@ha/*": ["../homeassistant-frontend/src/*"],
+    },
     "plugins": [
       {
         "name": "ts-lit-plugin",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7639,7 +7639,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.9.3":
+"enhanced-resolve@npm:^5.7.0, enhanced-resolve@npm:^5.9.3":
   version: 5.12.0
   resolution: "enhanced-resolve@npm:5.12.0"
   dependencies:
@@ -11056,6 +11056,7 @@ __metadata:
     terser-webpack-plugin: 5.3.6
     tinykeys: 1.4.0
     ts-lit-plugin: 1.2.1
+    tsconfig-paths-webpack-plugin: ^4.0.1
     tsparticles-engine: 2.9.3
     tsparticles-preset-links: 2.9.3
     typescript: 4.9.5
@@ -15197,6 +15198,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsconfig-paths-webpack-plugin@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "tsconfig-paths-webpack-plugin@npm:4.0.1"
+  dependencies:
+    chalk: ^4.1.0
+    enhanced-resolve: ^5.7.0
+    tsconfig-paths: ^4.1.2
+  checksum: a09e765c4939379fa060f78bbc906d0a7be541b9b49d3ad4744e99a2e87f28aa30d549a549196159bc5a50f420fdb1391b8eed360f47ee8ce40e15dcb800b5aa
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^3.14.1":
   version: 3.14.2
   resolution: "tsconfig-paths@npm:3.14.2"
@@ -15206,6 +15218,17 @@ __metadata:
     minimist: ^1.2.6
     strip-bom: ^3.0.0
   checksum: a6162eaa1aed680537f93621b82399c7856afd10ec299867b13a0675e981acac4e0ec00896860480efc59fc10fd0b16fdc928c0b885865b52be62cadac692447
+  languageName: node
+  linkType: hard
+
+"tsconfig-paths@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "tsconfig-paths@npm:4.1.2"
+  dependencies:
+    json5: ^2.2.2
+    minimist: ^1.2.6
+    strip-bom: ^3.0.0
+  checksum: 3d9151ecea139594e25618717de15769ab9f38f8e6d510ac16e592b23e7f7105ea13cec5694c3de7e132c98277b775e18edd1651964164ee6d75737c408494cc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Use `@ha` instead of relative imports for homeassistant-frontend components.

For webpack to work with that https://github.com/dividab/tsconfig-paths-webpack-plugin is added.

I think its better readable and it will also pave the way for `eslint` to pass.