### PR TITLE
chore: lint, sort, format, repeat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,39 @@ env:
   NODE_VERSION: 16
 
 jobs:
-  build_frontend:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out files from GitHub
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up Node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - name: Install dependencies
+        run: script/bootstrap
+
+      - name: Run eslint
+        run: yarn run lint:eslint
+
+      - name: Run prettier
+        run: yarn run lint:prettier
+
+      - name: Check for duplicate dependencies
+        run: yarn dedupe --check
+
+  build:
     name: Build
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out files from GitHub
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "Build"
+name: "CI"
 
 on:
   push:

--- a/src/knx-router.ts
+++ b/src/knx-router.ts
@@ -54,7 +54,7 @@ class KnxRouter extends HassRouterPage {
     // eslint-disable-next-line no-console
     console.info("Route " + this.route.path + " in knx-router");
 
-    if (this._currentPage != "devices") {
+    if (this._currentPage !== "devices") {
       const routeSplit = this.routeTail.path.split("/");
       el.deviceId = routeSplit[routeSplit.length - 1];
 

--- a/src/knx-router.ts
+++ b/src/knx-router.ts
@@ -1,8 +1,5 @@
 import { customElement, property, state } from "lit/decorators";
-import {
-  HassRouterPage,
-  RouterOptions,
-} from "@ha/layouts/hass-router-page";
+import { HassRouterPage, RouterOptions } from "@ha/layouts/hass-router-page";
 import { HomeAssistant, Route } from "@ha/types";
 import { KNX } from "./types/knx";
 

--- a/src/knx-router.ts
+++ b/src/knx-router.ts
@@ -1,6 +1,8 @@
 import { customElement, property, state } from "lit/decorators";
+
 import { HassRouterPage, RouterOptions } from "@ha/layouts/hass-router-page";
 import { HomeAssistant, Route } from "@ha/types";
+
 import { KNX } from "./types/knx";
 
 @customElement("knx-router")

--- a/src/knx.ts
+++ b/src/knx.ts
@@ -1,8 +1,10 @@
 import { LitElement } from "lit";
 import { property } from "lit/decorators";
+
 import { getConfigEntries } from "@ha/data/config_entries";
 import { ProvideHassLitMixin } from "@ha/mixins/provide-hass-lit-mixin";
 import { HomeAssistant } from "@ha/types";
+
 import { localize } from "./localize/localize";
 import { KNXLogger } from "./tools/knx-logger";
 import { KNX } from "./types/knx";

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@
 // import "@material/mwc-list/mwc-list-item";
 // import "@material/mwc-button";
 // import "@material/mwc-fab";
-import { html, nothing, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 
 import { applyThemesOnElement } from "@ha/common/dom/apply_themes_on_element";

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,19 +5,21 @@
 // import "@material/mwc-fab";
 import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
+
 import { applyThemesOnElement } from "@ha/common/dom/apply_themes_on_element";
+import "@ha/components/ha-menu-button";
+import "@ha/components/ha-tabs";
 import { navigate } from "@ha/common/navigate";
 import { makeDialogManager } from "@ha/dialogs/make-dialog-manager";
-import "@ha/resources/ha-style";
-import "@ha/components/ha-tabs";
-import "@ha/components/ha-menu-button";
 import "@ha/layouts/ha-app-layout";
 import "@ha/layouts/hass-subpage";
+import "@ha/resources/ha-style";
+import { haStyle } from "@ha/resources/styles";
 import { HomeAssistant, Route } from "@ha/types";
+
 import { knxElement } from "./knx";
 import "./knx-router";
 import { LocationChangedEvent } from "./types/navigation";
-import { haStyle } from "@ha/resources/styles";
 
 @customElement("knx-frontend")
 class KnxFrontend extends knxElement {

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,9 +48,9 @@ class KnxFrontend extends knxElement {
     this._applyTheme();
   }
 
-  protected render(): TemplateResult | void {
+  protected render() {
     if (!this.hass || !this.knx) {
-      return html`${nothing}`;
+      return nothing;
     }
 
     return html`

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@
 // import "@material/mwc-list/mwc-list-item";
 // import "@material/mwc-button";
 // import "@material/mwc-fab";
-import {css, html, TemplateResult} from "lit";
+import { css, html, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
 import { applyThemesOnElement } from "@ha/common/dom/apply_themes_on_element";
 import { navigate } from "@ha/common/navigate";
@@ -17,7 +17,7 @@ import { HomeAssistant, Route } from "@ha/types";
 import { knxElement } from "./knx";
 import "./knx-router";
 import { LocationChangedEvent } from "./types/navigation";
-import {haStyle} from "@ha/resources/styles";
+import { haStyle } from "@ha/resources/styles";
 
 @customElement("knx-frontend")
 class KnxFrontend extends knxElement {
@@ -59,10 +59,10 @@ class KnxFrontend extends knxElement {
             <div main-title>KNX UI</div>
           </app-toolbar>
           <ha-tabs
-              scrollable
-              attr-for-selected="page-name"
-              .selected=${this.route.path}
-              @iron-activate=${this.handleNavigationEvent}
+            scrollable
+            attr-for-selected="page-name"
+            .selected=${this.route.path}
+            @iron-activate=${this.handleNavigationEvent}
           >
             <paper-tab page-name="/knx/overview"> Overview </paper-tab>
             <paper-tab page-name="/knx/monitor"> Bus Monitor </paper-tab>
@@ -80,7 +80,7 @@ class KnxFrontend extends knxElement {
 
   private handleNavigationEvent(event: any) {
     const path = event.detail.item.getAttribute("page-name");
-    navigate(path, {replace: true});
+    navigate(path, { replace: true });
   }
 
   static get styles() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@
 // import "@material/mwc-list/mwc-list-item";
 // import "@material/mwc-button";
 // import "@material/mwc-fab";
-import { css, html, TemplateResult } from "lit";
+import { html, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
 import { applyThemesOnElement } from "@ha/common/dom/apply_themes_on_element";
 import { navigate } from "@ha/common/navigate";
@@ -35,7 +35,7 @@ class KnxFrontend extends knxElement {
     if (!this.knx) {
       this._getKNXConfigEntry();
     }
-    //this.knx.language = this.hass.language;
+    // this.knx.language = this.hass.language;
     this.addEventListener("knx-location-changed", (e) => this._setRoute(e as LocationChangedEvent));
 
     makeDialogManager(this, this.shadowRoot!);

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@
 // import "@material/mwc-list/mwc-list-item";
 // import "@material/mwc-button";
 // import "@material/mwc-fab";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators";
 import { applyThemesOnElement } from "@ha/common/dom/apply_themes_on_element";
 import { navigate } from "@ha/common/navigate";
@@ -48,7 +48,7 @@ class KnxFrontend extends knxElement {
 
   protected render(): TemplateResult | void {
     if (!this.hass || !this.knx) {
-      return html``;
+      return html`${nothing}`;
     }
 
     return html`

--- a/src/views/bus_monitor.ts
+++ b/src/views/bus_monitor.ts
@@ -23,7 +23,9 @@ import { KNXTelegram } from "../types/websocket";
 @customElement("knx-bus-monitor")
 export class KNXBusMonitor extends LitElement {
   @property({ type: Object }) public hass!: HomeAssistant;
+
   @property({ type: Boolean, reflect: true }) public narrow!: boolean;
+
   @property() private columns: DataTableColumnContainer = {
     timestamp: {
       filterable: true,
@@ -62,6 +64,7 @@ export class KNXBusMonitor extends LitElement {
   };
 
   @state() private subscribed?: () => void;
+
   @state() private rows: DataTableRowData[] = [];
 
   public disconnectedCallback() {

--- a/src/views/bus_monitor.ts
+++ b/src/views/bus_monitor.ts
@@ -5,6 +5,7 @@
 // import "@polymer/app-layout/app-toolbar/app-toolbar";
 import { css, html, CSSResultGroup, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
+
 import { computeRTLDirection } from "@ha/common/util/compute_rtl";
 import "@ha/components/data-table/ha-data-table";
 import type {
@@ -17,6 +18,7 @@ import "@ha/layouts/ha-app-layout";
 import "@ha/layouts/hass-subpage";
 import { haStyle } from "@ha/resources/styles";
 import { HomeAssistant } from "@ha/types";
+
 import { subscribeKnxTelegrams } from "../services/websocket.service";
 import { KNXTelegram } from "../types/websocket";
 

--- a/src/views/overview.ts
+++ b/src/views/overview.ts
@@ -1,10 +1,12 @@
 import { css, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
+
 import "@ha/components/ha-button-menu";
 import "@ha/components/ha-card";
 import "@ha/layouts/ha-app-layout";
 import "@ha/layouts/hass-subpage";
 import { HomeAssistant } from "@ha/types";
+
 import { getKnxInfo } from "../services/websocket.service";
 import { KNXInfo } from "../types/websocket";
 

--- a/src/views/overview.ts
+++ b/src/views/overview.ts
@@ -11,7 +11,9 @@ import { KNXInfo } from "../types/websocket";
 @customElement("knx-overview")
 export class KNXOverview extends LitElement {
   @property({ type: Object }) public hass!: HomeAssistant;
+
   @property({ type: Boolean, reflect: true }) public narrow!: boolean;
+
   @state() private knxInfo: KNXInfo | null = null;
 
   protected firstUpdated() {


### PR DESCRIPTION
- Removed some unused imports.
- use `nothing` when returning empty template.
- use !== instead of !=
- Sort imports, add empty line between lit, ha and knx imports.