### PR TITLE
Prepopulate group monitor table with recent telegrams

### DIFF
--- a/src/services/websocket.service.ts
+++ b/src/services/websocket.service.ts
@@ -1,5 +1,5 @@
 import { HomeAssistant } from "@ha/types";
-import { KNXInfoData, KNXTelegram, GroupMonitorInfo } from "../types/websocket";
+import { KNXInfoData, KNXTelegram, GroupMonitorInfoData } from "../types/websocket";
 
 export const getKnxInfoData = (hass: HomeAssistant): Promise<KNXInfoData> =>
   hass.callWS({
@@ -22,7 +22,7 @@ export const removeProjectFile = (hass: HomeAssistant): Promise<void> =>
     type: "knx/project_file_remove",
   });
 
-export const getGroupMonitorInfo = (hass: HomeAssistant): Promise<GroupMonitorInfo> =>
+export const getGroupMonitorInfo = (hass: HomeAssistant): Promise<GroupMonitorInfoData> =>
   hass.callWS({
     type: "knx/group_monitor_info",
   });

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -11,8 +11,9 @@ export interface KNXProjectInfo {
   tool_version: string;
 }
 
-export interface GroupMonitorInfo {
+export interface GroupMonitorInfoData {
   project_loaded: boolean;
+  recent_telegrams: KNXTelegram[];
 }
 
 export interface KNXTelegram {
@@ -23,6 +24,6 @@ export interface KNXTelegram {
   payload: string;
   type: string;
   direction: string;
-  timestamp: Date;
+  timestamp: string;
   value: string;
 }


### PR DESCRIPTION
The integration counterpart is found here: [Send recent telegrams at once on connection of group monitor](https://github.com/home-assistant/core/pull/93153/commits/20f9b8f17dcb9eddb236f2c2b87ef092bc90adf3)
in https://github.com/home-assistant/core/pull/93153