### PR TITLE
Add `yarn install` to upstream when updating HA-frontend

### DIFF
--- a/script/upgrade-frontend
+++ b/script/upgrade-frontend
@@ -11,13 +11,16 @@ cd homeassistant-frontend
 git fetch --tags
 latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
 git checkout $latestTag
+
+echo "Installing upstream modules"
+yarn install
+
 cd ..
 
-# echo "Removing yarn.lock"
-# rm -f yarn.lock
+# KNX Frontend
 
 echo "Merging requirements"
 node ./script/merge_requirements.cjs
 
-echo "Installing modules"
+echo "Installing knx-frontend modules"
 yarn install


### PR DESCRIPTION
Since `/homeassistant-frontend/node_modules` is used, but not updated when checking out a new branch (as it is listed in `.gitignore`) it would stay on older versions.