### PR TITLE
Update scripts for HA-FE updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,8 +160,8 @@
   "devDependencies": {
     "@babel/core": "7.22.1",
     "@babel/plugin-proposal-decorators": "7.22.3",
-    "@babel/plugin-transform-runtime": "7.22.2",
-    "@babel/preset-env": "7.22.2",
+    "@babel/plugin-transform-runtime": "7.22.4",
+    "@babel/preset-env": "7.22.4",
     "@babel/preset-typescript": "7.21.5",
     "@koa/cors": "4.0.0",
     "@octokit/auth-oauth-device": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -251,5 +251,6 @@
     "@polymer/polymer": "patch:@polymer/polymer@3.5.1#./homeassistant-frontend/.yarn/patches/@polymer/polymer/pr-5569.patch",
     "@material/mwc-button@^0.25.3": "^0.27.0",
     "sortablejs@1.15.0": "patch:sortablejs@npm%3A1.15.0#./homeassistant-frontend/.yarn/patches/sortablejs-npm-1.15.0-f3a393abcc.patch"
-  }
+  },
+  "packageManager": "yarn@3.5.1"
 }

--- a/package.json
+++ b/package.json
@@ -20,16 +20,11 @@
   "author": "Marvin Wichmann <me@marvin-wichmann.de>",
   "license": "MIT",
   "type": "module",
-  "resolutions": {
-    "@polymer/polymer": "patch:@polymer/polymer@3.5.1#./homeassistant-frontend/.yarn/patches/@polymer/polymer/pr-5569.patch",
-    "@material/mwc-button@^0.25.3": "^0.27.0",
-    "sortablejs@1.15.0": "patch:sortablejs@npm%3A1.15.0#./homeassistant-frontend/.yarn/patches/sortablejs-npm-1.15.0-f3a393abcc.patch"
-  },
-  "resolutionsOverride": {},
   "dependenciesOverride": {},
   "devDependenciesOverride": {
     "tsconfig-paths-webpack-plugin": "^4.0.1"
   },
+  "resolutionsOverride": {},
   "dependencies": {
     "@babel/runtime": "7.22.3",
     "@braintree/sanitize-url": "6.0.2",
@@ -251,5 +246,10 @@
     "webpackbar": "5.0.2",
     "workbox-build": "6.6.0",
     "tsconfig-paths-webpack-plugin": "^4.0.1"
+  },
+  "resolutions": {
+    "@polymer/polymer": "patch:@polymer/polymer@3.5.1#./homeassistant-frontend/.yarn/patches/@polymer/polymer/pr-5569.patch",
+    "@material/mwc-button@^0.25.3": "^0.27.0",
+    "sortablejs@1.15.0": "patch:sortablejs@npm%3A1.15.0#./homeassistant-frontend/.yarn/patches/sortablejs-npm-1.15.0-f3a393abcc.patch"
   }
 }

--- a/package.json
+++ b/package.json
@@ -236,6 +236,7 @@
     "tar": "6.1.15",
     "terser-webpack-plugin": "5.3.9",
     "ts-lit-plugin": "1.2.1",
+    "tsconfig-paths-webpack-plugin": "^4.0.1",
     "typescript": "4.9.5",
     "vinyl-buffer": "1.0.1",
     "vinyl-source-stream": "2.0.0",
@@ -244,8 +245,7 @@
     "webpack-dev-server": "4.15.0",
     "webpack-manifest-plugin": "5.0.0",
     "webpackbar": "5.0.2",
-    "workbox-build": "6.6.0",
-    "tsconfig-paths-webpack-plugin": "^4.0.1"
+    "workbox-build": "6.6.0"
   },
   "resolutions": {
     "@polymer/polymer": "patch:@polymer/polymer@3.5.1#./homeassistant-frontend/.yarn/patches/@polymer/polymer/pr-5569.patch",

--- a/package.json
+++ b/package.json
@@ -21,14 +21,11 @@
   "license": "MIT",
   "type": "module",
   "resolutions": {
-    "@polymer/polymer": "patch:@polymer/polymer@3.4.1#./homeassistant-frontend/.yarn/patches/@polymer/polymer/pr-5569.patch",
+    "@polymer/polymer": "patch:@polymer/polymer@3.5.1#./homeassistant-frontend/.yarn/patches/@polymer/polymer/pr-5569.patch",
     "@material/mwc-button@^0.25.3": "^0.27.0",
     "sortablejs@1.15.0": "patch:sortablejs@npm%3A1.15.0#./homeassistant-frontend/.yarn/patches/sortablejs-npm-1.15.0-f3a393abcc.patch"
   },
-  "resolutionsOverride": {
-    "@polymer/polymer": "patch:@polymer/polymer@3.4.1#./homeassistant-frontend/.yarn/patches/@polymer/polymer/pr-5569.patch",
-    "sortablejs@1.15.0": "patch:sortablejs@npm%3A1.15.0#./homeassistant-frontend/.yarn/patches/sortablejs-npm-1.15.0-f3a393abcc.patch"
-  },
+  "resolutionsOverride": {},
   "dependenciesOverride": {},
   "devDependenciesOverride": {
     "tsconfig-paths-webpack-plugin": "^4.0.1"
@@ -244,7 +241,6 @@
     "tar": "6.1.15",
     "terser-webpack-plugin": "5.3.9",
     "ts-lit-plugin": "1.2.1",
-    "tsconfig-paths-webpack-plugin": "^4.0.1",
     "typescript": "4.9.5",
     "vinyl-buffer": "1.0.1",
     "vinyl-source-stream": "2.0.0",
@@ -253,6 +249,7 @@
     "webpack-dev-server": "4.15.0",
     "webpack-manifest-plugin": "5.0.0",
     "webpackbar": "5.0.2",
-    "workbox-build": "6.6.0"
+    "workbox-build": "6.6.0",
+    "tsconfig-paths-webpack-plugin": "^4.0.1"
   }
 }

--- a/script/merge_requirements.js
+++ b/script/merge_requirements.js
@@ -18,12 +18,12 @@ fs.writeFileSync(
   JSON.stringify(
     {
       ...packageKnx,
-      resolutions: { ...subdir_resolutions, ...packageKnx.resolutionsOverride },
       dependencies: { ...packageCore.dependencies, ...packageKnx.dependenciesOverride },
       devDependencies: {
         ...packageCore.devDependencies,
         ...packageKnx.devDependenciesOverride,
       },
+      resolutions: { ...subdir_resolutions, ...packageKnx.resolutionsOverride },
     },
     null,
     2

--- a/script/merge_requirements.js
+++ b/script/merge_requirements.js
@@ -6,12 +6,19 @@ const rawPackageKnx = fs.readFileSync("./package.json");
 const packageCore = JSON.parse(rawPackageCore);
 const packageKnx = JSON.parse(rawPackageKnx);
 
+const subdir_resolutions = Object.fromEntries(
+  Object.entries(packageCore.resolutions).map(([key, value]) => [
+    key,
+    value.replace(/#\.\//g, "#./homeassistant-frontend/"),
+  ])
+);
+
 fs.writeFileSync(
   "./package.json",
   JSON.stringify(
     {
       ...packageKnx,
-      resolutions: { ...packageCore.resolutions, ...packageKnx.resolutionsOverride },
+      resolutions: { ...subdir_resolutions, ...packageKnx.resolutionsOverride },
       dependencies: { ...packageCore.dependencies, ...packageKnx.dependenciesOverride },
       devDependencies: {
         ...packageCore.devDependencies,
@@ -23,6 +30,6 @@ fs.writeFileSync(
   )
 );
 
-const yarnRcCore = fs.readFileSync("./homeassistant-frontend/.yarnrc.yml", 'utf8');
-const yarnRcKnx = yarnRcCore.replace(/\.yarn\//g, "homeassistant-frontend/.yarn/")
+const yarnRcCore = fs.readFileSync("./homeassistant-frontend/.yarnrc.yml", "utf8");
+const yarnRcKnx = yarnRcCore.replace(/\.yarn\//g, "homeassistant-frontend/.yarn/");
 fs.writeFileSync("./.yarnrc.yml", yarnRcKnx);

--- a/script/merge_requirements.js
+++ b/script/merge_requirements.js
@@ -24,6 +24,7 @@ fs.writeFileSync(
         ...packageKnx.devDependenciesOverride,
       },
       resolutions: { ...subdir_resolutions, ...packageKnx.resolutionsOverride },
+      packageManager: packageCore.packageManager,
     },
     null,
     2

--- a/script/upgrade-frontend
+++ b/script/upgrade-frontend
@@ -37,6 +37,7 @@ node ./script/merge_requirements.js
 
 echo "Installing modules"
 yarn install
+yarn dedupe
 
 echo "\nUpdated HA frontend from $previousTag to $newTag"
 echo "Here is the diff: https://github.com/home-assistant/frontend/compare/$previousTag..$newTag"

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,7 +386,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.22.0, @babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.22.3":
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:7.22.3"
   dependencies:
@@ -517,7 +517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-import-attributes@npm:^7.22.0, @babel/plugin-syntax-import-attributes@npm:^7.22.3":
+"@babel/plugin-syntax-import-attributes@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-syntax-import-attributes@npm:7.22.3"
   dependencies:
@@ -683,7 +683,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-async-generator-functions@npm:^7.22.0, @babel/plugin-transform-async-generator-functions@npm:^7.22.3":
+"@babel/plugin-transform-async-generator-functions@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-async-generator-functions@npm:7.22.3"
   dependencies:
@@ -732,7 +732,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-class-properties@npm:^7.22.0, @babel/plugin-transform-class-properties@npm:^7.22.3":
+"@babel/plugin-transform-class-properties@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-class-properties@npm:7.22.3"
   dependencies:
@@ -744,7 +744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-class-static-block@npm:^7.22.0, @babel/plugin-transform-class-static-block@npm:^7.22.3":
+"@babel/plugin-transform-class-static-block@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-class-static-block@npm:7.22.3"
   dependencies:
@@ -846,7 +846,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-export-namespace-from@npm:^7.22.0, @babel/plugin-transform-export-namespace-from@npm:^7.22.3":
+"@babel/plugin-transform-export-namespace-from@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-export-namespace-from@npm:7.22.3"
   dependencies:
@@ -882,7 +882,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-json-strings@npm:^7.22.0, @babel/plugin-transform-json-strings@npm:^7.22.3":
+"@babel/plugin-transform-json-strings@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-json-strings@npm:7.22.3"
   dependencies:
@@ -905,7 +905,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-logical-assignment-operators@npm:^7.22.0, @babel/plugin-transform-logical-assignment-operators@npm:^7.22.3":
+"@babel/plugin-transform-logical-assignment-operators@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-logical-assignment-operators@npm:7.22.3"
   dependencies:
@@ -953,7 +953,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-systemjs@npm:^7.22.0, @babel/plugin-transform-modules-systemjs@npm:^7.22.3":
+"@babel/plugin-transform-modules-systemjs@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-modules-systemjs@npm:7.22.3"
   dependencies:
@@ -979,7 +979,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.22.0, @babel/plugin-transform-named-capturing-groups-regex@npm:^7.22.3":
+"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.22.3"
   dependencies:
@@ -991,7 +991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-new-target@npm:^7.22.0, @babel/plugin-transform-new-target@npm:^7.22.3":
+"@babel/plugin-transform-new-target@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-new-target@npm:7.22.3"
   dependencies:
@@ -1002,7 +1002,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.22.0, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.22.3":
+"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.22.3"
   dependencies:
@@ -1014,7 +1014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-numeric-separator@npm:^7.22.0, @babel/plugin-transform-numeric-separator@npm:^7.22.3":
+"@babel/plugin-transform-numeric-separator@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-numeric-separator@npm:7.22.3"
   dependencies:
@@ -1026,7 +1026,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-object-rest-spread@npm:^7.22.0, @babel/plugin-transform-object-rest-spread@npm:^7.22.3":
+"@babel/plugin-transform-object-rest-spread@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-object-rest-spread@npm:7.22.3"
   dependencies:
@@ -1053,7 +1053,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-optional-catch-binding@npm:^7.22.0, @babel/plugin-transform-optional-catch-binding@npm:^7.22.3":
+"@babel/plugin-transform-optional-catch-binding@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-optional-catch-binding@npm:7.22.3"
   dependencies:
@@ -1065,7 +1065,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-optional-chaining@npm:^7.22.0, @babel/plugin-transform-optional-chaining@npm:^7.22.3":
+"@babel/plugin-transform-optional-chaining@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-optional-chaining@npm:7.22.3"
   dependencies:
@@ -1078,7 +1078,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-parameters@npm:^7.22.0, @babel/plugin-transform-parameters@npm:^7.22.3":
+"@babel/plugin-transform-parameters@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-parameters@npm:7.22.3"
   dependencies:
@@ -1089,7 +1089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-private-methods@npm:^7.22.0, @babel/plugin-transform-private-methods@npm:^7.22.3":
+"@babel/plugin-transform-private-methods@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-private-methods@npm:7.22.3"
   dependencies:
@@ -1101,7 +1101,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-private-property-in-object@npm:^7.22.0, @babel/plugin-transform-private-property-in-object@npm:^7.22.3":
+"@babel/plugin-transform-private-property-in-object@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-private-property-in-object@npm:7.22.3"
   dependencies:
@@ -1246,7 +1246,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-unicode-property-regex@npm:^7.22.0, @babel/plugin-transform-unicode-property-regex@npm:^7.22.3":
+"@babel/plugin-transform-unicode-property-regex@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-unicode-property-regex@npm:7.22.3"
   dependencies:
@@ -1270,7 +1270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-unicode-sets-regex@npm:^7.22.0, @babel/plugin-transform-unicode-sets-regex@npm:^7.22.3":
+"@babel/plugin-transform-unicode-sets-regex@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-unicode-sets-regex@npm:7.22.3"
   dependencies:
@@ -1282,7 +1282,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:7.22.4":
+"@babel/preset-env@npm:7.22.4, @babel/preset-env@npm:^7.11.0":
   version: 7.22.4
   resolution: "@babel/preset-env@npm:7.22.4"
   dependencies:
@@ -1369,96 +1369,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 68ae8b712e7548cb0aa593019bf22ed473bd83887c621c1f820ef0af99958d48b687c01b8aee16035cbc70edae1edc703b892e6efed14b95c8435343a2cb2bda
-  languageName: node
-  linkType: hard
-
-"@babel/preset-env@npm:^7.11.0":
-  version: 7.22.2
-  resolution: "@babel/preset-env@npm:7.22.2"
-  dependencies:
-    "@babel/compat-data": ^7.22.0
-    "@babel/helper-compilation-targets": ^7.22.1
-    "@babel/helper-plugin-utils": ^7.21.5
-    "@babel/helper-validator-option": ^7.21.0
-    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": ^7.18.6
-    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": ^7.22.0
-    "@babel/plugin-proposal-private-property-in-object": ^7.21.0
-    "@babel/plugin-syntax-async-generators": ^7.8.4
-    "@babel/plugin-syntax-class-properties": ^7.12.13
-    "@babel/plugin-syntax-class-static-block": ^7.14.5
-    "@babel/plugin-syntax-dynamic-import": ^7.8.3
-    "@babel/plugin-syntax-export-namespace-from": ^7.8.3
-    "@babel/plugin-syntax-import-assertions": ^7.20.0
-    "@babel/plugin-syntax-import-attributes": ^7.22.0
-    "@babel/plugin-syntax-import-meta": ^7.10.4
-    "@babel/plugin-syntax-json-strings": ^7.8.3
-    "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
-    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3
-    "@babel/plugin-syntax-numeric-separator": ^7.10.4
-    "@babel/plugin-syntax-object-rest-spread": ^7.8.3
-    "@babel/plugin-syntax-optional-catch-binding": ^7.8.3
-    "@babel/plugin-syntax-optional-chaining": ^7.8.3
-    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
-    "@babel/plugin-syntax-top-level-await": ^7.14.5
-    "@babel/plugin-syntax-unicode-sets-regex": ^7.18.6
-    "@babel/plugin-transform-arrow-functions": ^7.21.5
-    "@babel/plugin-transform-async-generator-functions": ^7.22.0
-    "@babel/plugin-transform-async-to-generator": ^7.20.7
-    "@babel/plugin-transform-block-scoped-functions": ^7.18.6
-    "@babel/plugin-transform-block-scoping": ^7.21.0
-    "@babel/plugin-transform-class-properties": ^7.22.0
-    "@babel/plugin-transform-class-static-block": ^7.22.0
-    "@babel/plugin-transform-classes": ^7.21.0
-    "@babel/plugin-transform-computed-properties": ^7.21.5
-    "@babel/plugin-transform-destructuring": ^7.21.3
-    "@babel/plugin-transform-dotall-regex": ^7.18.6
-    "@babel/plugin-transform-duplicate-keys": ^7.18.9
-    "@babel/plugin-transform-dynamic-import": ^7.22.1
-    "@babel/plugin-transform-exponentiation-operator": ^7.18.6
-    "@babel/plugin-transform-export-namespace-from": ^7.22.0
-    "@babel/plugin-transform-for-of": ^7.21.5
-    "@babel/plugin-transform-function-name": ^7.18.9
-    "@babel/plugin-transform-json-strings": ^7.22.0
-    "@babel/plugin-transform-literals": ^7.18.9
-    "@babel/plugin-transform-logical-assignment-operators": ^7.22.0
-    "@babel/plugin-transform-member-expression-literals": ^7.18.6
-    "@babel/plugin-transform-modules-amd": ^7.20.11
-    "@babel/plugin-transform-modules-commonjs": ^7.21.5
-    "@babel/plugin-transform-modules-systemjs": ^7.22.0
-    "@babel/plugin-transform-modules-umd": ^7.18.6
-    "@babel/plugin-transform-named-capturing-groups-regex": ^7.22.0
-    "@babel/plugin-transform-new-target": ^7.22.0
-    "@babel/plugin-transform-nullish-coalescing-operator": ^7.22.0
-    "@babel/plugin-transform-numeric-separator": ^7.22.0
-    "@babel/plugin-transform-object-rest-spread": ^7.22.0
-    "@babel/plugin-transform-object-super": ^7.18.6
-    "@babel/plugin-transform-optional-catch-binding": ^7.22.0
-    "@babel/plugin-transform-optional-chaining": ^7.22.0
-    "@babel/plugin-transform-parameters": ^7.22.0
-    "@babel/plugin-transform-private-methods": ^7.22.0
-    "@babel/plugin-transform-private-property-in-object": ^7.22.0
-    "@babel/plugin-transform-property-literals": ^7.18.6
-    "@babel/plugin-transform-regenerator": ^7.21.5
-    "@babel/plugin-transform-reserved-words": ^7.18.6
-    "@babel/plugin-transform-shorthand-properties": ^7.18.6
-    "@babel/plugin-transform-spread": ^7.20.7
-    "@babel/plugin-transform-sticky-regex": ^7.18.6
-    "@babel/plugin-transform-template-literals": ^7.18.9
-    "@babel/plugin-transform-typeof-symbol": ^7.18.9
-    "@babel/plugin-transform-unicode-escapes": ^7.21.5
-    "@babel/plugin-transform-unicode-property-regex": ^7.22.0
-    "@babel/plugin-transform-unicode-regex": ^7.18.6
-    "@babel/plugin-transform-unicode-sets-regex": ^7.22.0
-    "@babel/preset-modules": ^0.1.5
-    "@babel/types": ^7.22.0
-    babel-plugin-polyfill-corejs2: ^0.4.2
-    babel-plugin-polyfill-corejs3: ^0.8.1
-    babel-plugin-polyfill-regenerator: ^0.5.0
-    core-js-compat: ^3.30.2
-    semver: ^6.3.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: bf74b935bcd59ca2274309bf82c3ee1341ab45cd83e2c8d80bca87a776202d3f719c64c2a5ccb223735b60dec03112f7a73c89ad829e168f99eadc4accf84b4b
   languageName: node
   linkType: hard
 
@@ -6149,7 +6059,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs2@npm:^0.4.2, babel-plugin-polyfill-corejs2@npm:^0.4.3":
+"babel-plugin-polyfill-corejs2@npm:^0.4.3":
   version: 0.4.3
   resolution: "babel-plugin-polyfill-corejs2@npm:0.4.3"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,7 +386,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.22.0":
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.22.0, @babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:7.22.3"
   dependencies:
@@ -517,7 +517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-import-attributes@npm:^7.22.0":
+"@babel/plugin-syntax-import-attributes@npm:^7.22.0, @babel/plugin-syntax-import-attributes@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-syntax-import-attributes@npm:7.22.3"
   dependencies:
@@ -683,7 +683,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-async-generator-functions@npm:^7.22.0":
+"@babel/plugin-transform-async-generator-functions@npm:^7.22.0, @babel/plugin-transform-async-generator-functions@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-async-generator-functions@npm:7.22.3"
   dependencies:
@@ -732,7 +732,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-class-properties@npm:^7.22.0":
+"@babel/plugin-transform-class-properties@npm:^7.22.0, @babel/plugin-transform-class-properties@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-class-properties@npm:7.22.3"
   dependencies:
@@ -744,7 +744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-class-static-block@npm:^7.22.0":
+"@babel/plugin-transform-class-static-block@npm:^7.22.0, @babel/plugin-transform-class-static-block@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-class-static-block@npm:7.22.3"
   dependencies:
@@ -846,7 +846,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-export-namespace-from@npm:^7.22.0":
+"@babel/plugin-transform-export-namespace-from@npm:^7.22.0, @babel/plugin-transform-export-namespace-from@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-export-namespace-from@npm:7.22.3"
   dependencies:
@@ -882,7 +882,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-json-strings@npm:^7.22.0":
+"@babel/plugin-transform-json-strings@npm:^7.22.0, @babel/plugin-transform-json-strings@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-json-strings@npm:7.22.3"
   dependencies:
@@ -905,7 +905,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-logical-assignment-operators@npm:^7.22.0":
+"@babel/plugin-transform-logical-assignment-operators@npm:^7.22.0, @babel/plugin-transform-logical-assignment-operators@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-logical-assignment-operators@npm:7.22.3"
   dependencies:
@@ -953,7 +953,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-systemjs@npm:^7.22.0":
+"@babel/plugin-transform-modules-systemjs@npm:^7.22.0, @babel/plugin-transform-modules-systemjs@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-modules-systemjs@npm:7.22.3"
   dependencies:
@@ -979,7 +979,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.22.0":
+"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.22.0, @babel/plugin-transform-named-capturing-groups-regex@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.22.3"
   dependencies:
@@ -991,7 +991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-new-target@npm:^7.22.0":
+"@babel/plugin-transform-new-target@npm:^7.22.0, @babel/plugin-transform-new-target@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-new-target@npm:7.22.3"
   dependencies:
@@ -1002,7 +1002,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.22.0":
+"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.22.0, @babel/plugin-transform-nullish-coalescing-operator@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.22.3"
   dependencies:
@@ -1014,7 +1014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-numeric-separator@npm:^7.22.0":
+"@babel/plugin-transform-numeric-separator@npm:^7.22.0, @babel/plugin-transform-numeric-separator@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-numeric-separator@npm:7.22.3"
   dependencies:
@@ -1026,7 +1026,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-object-rest-spread@npm:^7.22.0":
+"@babel/plugin-transform-object-rest-spread@npm:^7.22.0, @babel/plugin-transform-object-rest-spread@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-object-rest-spread@npm:7.22.3"
   dependencies:
@@ -1053,7 +1053,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-optional-catch-binding@npm:^7.22.0":
+"@babel/plugin-transform-optional-catch-binding@npm:^7.22.0, @babel/plugin-transform-optional-catch-binding@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-optional-catch-binding@npm:7.22.3"
   dependencies:
@@ -1089,7 +1089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-private-methods@npm:^7.22.0":
+"@babel/plugin-transform-private-methods@npm:^7.22.0, @babel/plugin-transform-private-methods@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-private-methods@npm:7.22.3"
   dependencies:
@@ -1101,7 +1101,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-private-property-in-object@npm:^7.22.0":
+"@babel/plugin-transform-private-property-in-object@npm:^7.22.0, @babel/plugin-transform-private-property-in-object@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-private-property-in-object@npm:7.22.3"
   dependencies:
@@ -1149,19 +1149,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:7.22.2":
-  version: 7.22.2
-  resolution: "@babel/plugin-transform-runtime@npm:7.22.2"
+"@babel/plugin-transform-runtime@npm:7.22.4":
+  version: 7.22.4
+  resolution: "@babel/plugin-transform-runtime@npm:7.22.4"
   dependencies:
     "@babel/helper-module-imports": ^7.21.4
     "@babel/helper-plugin-utils": ^7.21.5
-    babel-plugin-polyfill-corejs2: ^0.4.2
+    babel-plugin-polyfill-corejs2: ^0.4.3
     babel-plugin-polyfill-corejs3: ^0.8.1
     babel-plugin-polyfill-regenerator: ^0.5.0
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 1fedc30de67a921edca22505bfb31807b47634e413bb5ee42c194b6c70c32dceab9e4e4d0eaabadda7b45d975bf46cdfc8111c43c090ec8a19b1f722308ba9b1
+  checksum: e51400ffeccfc8875c6d136510aa6145e44d825ee7fb52da462401388b4303a6a274ca94fad4aa46b06870c6fdc6141dafa51f681423160d924a21212daa8792
   languageName: node
   linkType: hard
 
@@ -1246,7 +1246,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-unicode-property-regex@npm:^7.22.0":
+"@babel/plugin-transform-unicode-property-regex@npm:^7.22.0, @babel/plugin-transform-unicode-property-regex@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-unicode-property-regex@npm:7.22.3"
   dependencies:
@@ -1270,7 +1270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-unicode-sets-regex@npm:^7.22.0":
+"@babel/plugin-transform-unicode-sets-regex@npm:^7.22.0, @babel/plugin-transform-unicode-sets-regex@npm:^7.22.3":
   version: 7.22.3
   resolution: "@babel/plugin-transform-unicode-sets-regex@npm:7.22.3"
   dependencies:
@@ -1282,7 +1282,97 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:7.22.2, @babel/preset-env@npm:^7.11.0":
+"@babel/preset-env@npm:7.22.4":
+  version: 7.22.4
+  resolution: "@babel/preset-env@npm:7.22.4"
+  dependencies:
+    "@babel/compat-data": ^7.22.3
+    "@babel/helper-compilation-targets": ^7.22.1
+    "@babel/helper-plugin-utils": ^7.21.5
+    "@babel/helper-validator-option": ^7.21.0
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": ^7.18.6
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": ^7.22.3
+    "@babel/plugin-proposal-private-property-in-object": ^7.21.0
+    "@babel/plugin-syntax-async-generators": ^7.8.4
+    "@babel/plugin-syntax-class-properties": ^7.12.13
+    "@babel/plugin-syntax-class-static-block": ^7.14.5
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+    "@babel/plugin-syntax-export-namespace-from": ^7.8.3
+    "@babel/plugin-syntax-import-assertions": ^7.20.0
+    "@babel/plugin-syntax-import-attributes": ^7.22.3
+    "@babel/plugin-syntax-import-meta": ^7.10.4
+    "@babel/plugin-syntax-json-strings": ^7.8.3
+    "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
+    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3
+    "@babel/plugin-syntax-numeric-separator": ^7.10.4
+    "@babel/plugin-syntax-object-rest-spread": ^7.8.3
+    "@babel/plugin-syntax-optional-catch-binding": ^7.8.3
+    "@babel/plugin-syntax-optional-chaining": ^7.8.3
+    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
+    "@babel/plugin-syntax-top-level-await": ^7.14.5
+    "@babel/plugin-syntax-unicode-sets-regex": ^7.18.6
+    "@babel/plugin-transform-arrow-functions": ^7.21.5
+    "@babel/plugin-transform-async-generator-functions": ^7.22.3
+    "@babel/plugin-transform-async-to-generator": ^7.20.7
+    "@babel/plugin-transform-block-scoped-functions": ^7.18.6
+    "@babel/plugin-transform-block-scoping": ^7.21.0
+    "@babel/plugin-transform-class-properties": ^7.22.3
+    "@babel/plugin-transform-class-static-block": ^7.22.3
+    "@babel/plugin-transform-classes": ^7.21.0
+    "@babel/plugin-transform-computed-properties": ^7.21.5
+    "@babel/plugin-transform-destructuring": ^7.21.3
+    "@babel/plugin-transform-dotall-regex": ^7.18.6
+    "@babel/plugin-transform-duplicate-keys": ^7.18.9
+    "@babel/plugin-transform-dynamic-import": ^7.22.1
+    "@babel/plugin-transform-exponentiation-operator": ^7.18.6
+    "@babel/plugin-transform-export-namespace-from": ^7.22.3
+    "@babel/plugin-transform-for-of": ^7.21.5
+    "@babel/plugin-transform-function-name": ^7.18.9
+    "@babel/plugin-transform-json-strings": ^7.22.3
+    "@babel/plugin-transform-literals": ^7.18.9
+    "@babel/plugin-transform-logical-assignment-operators": ^7.22.3
+    "@babel/plugin-transform-member-expression-literals": ^7.18.6
+    "@babel/plugin-transform-modules-amd": ^7.20.11
+    "@babel/plugin-transform-modules-commonjs": ^7.21.5
+    "@babel/plugin-transform-modules-systemjs": ^7.22.3
+    "@babel/plugin-transform-modules-umd": ^7.18.6
+    "@babel/plugin-transform-named-capturing-groups-regex": ^7.22.3
+    "@babel/plugin-transform-new-target": ^7.22.3
+    "@babel/plugin-transform-nullish-coalescing-operator": ^7.22.3
+    "@babel/plugin-transform-numeric-separator": ^7.22.3
+    "@babel/plugin-transform-object-rest-spread": ^7.22.3
+    "@babel/plugin-transform-object-super": ^7.18.6
+    "@babel/plugin-transform-optional-catch-binding": ^7.22.3
+    "@babel/plugin-transform-optional-chaining": ^7.22.3
+    "@babel/plugin-transform-parameters": ^7.22.3
+    "@babel/plugin-transform-private-methods": ^7.22.3
+    "@babel/plugin-transform-private-property-in-object": ^7.22.3
+    "@babel/plugin-transform-property-literals": ^7.18.6
+    "@babel/plugin-transform-regenerator": ^7.21.5
+    "@babel/plugin-transform-reserved-words": ^7.18.6
+    "@babel/plugin-transform-shorthand-properties": ^7.18.6
+    "@babel/plugin-transform-spread": ^7.20.7
+    "@babel/plugin-transform-sticky-regex": ^7.18.6
+    "@babel/plugin-transform-template-literals": ^7.18.9
+    "@babel/plugin-transform-typeof-symbol": ^7.18.9
+    "@babel/plugin-transform-unicode-escapes": ^7.21.5
+    "@babel/plugin-transform-unicode-property-regex": ^7.22.3
+    "@babel/plugin-transform-unicode-regex": ^7.18.6
+    "@babel/plugin-transform-unicode-sets-regex": ^7.22.3
+    "@babel/preset-modules": ^0.1.5
+    "@babel/types": ^7.22.4
+    babel-plugin-polyfill-corejs2: ^0.4.3
+    babel-plugin-polyfill-corejs3: ^0.8.1
+    babel-plugin-polyfill-regenerator: ^0.5.0
+    core-js-compat: ^3.30.2
+    semver: ^6.3.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 68ae8b712e7548cb0aa593019bf22ed473bd83887c621c1f820ef0af99958d48b687c01b8aee16035cbc70edae1edc703b892e6efed14b95c8435343a2cb2bda
+  languageName: node
+  linkType: hard
+
+"@babel/preset-env@npm:^7.11.0":
   version: 7.22.2
   resolution: "@babel/preset-env@npm:7.22.2"
   dependencies:
@@ -1447,7 +1537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.5, @babel/types@npm:^7.21.0, @babel/types@npm:^7.21.4, @babel/types@npm:^7.21.5, @babel/types@npm:^7.22.0, @babel/types@npm:^7.22.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
+"@babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.5, @babel/types@npm:^7.21.0, @babel/types@npm:^7.21.4, @babel/types@npm:^7.21.5, @babel/types@npm:^7.22.0, @babel/types@npm:^7.22.3, @babel/types@npm:^7.22.4, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.22.4
   resolution: "@babel/types@npm:7.22.4"
   dependencies:
@@ -6059,7 +6149,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs2@npm:^0.4.2":
+"babel-plugin-polyfill-corejs2@npm:^0.4.2, babel-plugin-polyfill-corejs2@npm:^0.4.3":
   version: 0.4.3
   resolution: "babel-plugin-polyfill-corejs2@npm:0.4.3"
   dependencies:
@@ -10968,8 +11058,8 @@ __metadata:
   dependencies:
     "@babel/core": 7.22.1
     "@babel/plugin-proposal-decorators": 7.22.3
-    "@babel/plugin-transform-runtime": 7.22.2
-    "@babel/preset-env": 7.22.2
+    "@babel/plugin-transform-runtime": 7.22.4
+    "@babel/preset-env": 7.22.4
     "@babel/preset-typescript": 7.21.5
     "@babel/runtime": 7.22.3
     "@braintree/sanitize-url": 6.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -3814,21 +3814,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polymer/polymer@npm:3.4.1":
-  version: 3.4.1
-  resolution: "@polymer/polymer@npm:3.4.1"
+"@polymer/polymer@npm:3.5.1":
+  version: 3.5.1
+  resolution: "@polymer/polymer@npm:3.5.1"
   dependencies:
     "@webcomponents/shadycss": ^1.9.1
-  checksum: 0f80eb8af291ac900d93daac36be2ec98ebb618df3e9ef6e904742ffbd9c82132373082953ddda67d68f32c4a17fafc311ba496b56937535c3f4eb360b55fd51
+  checksum: 4c499cd817e8ca79ad192d1006f7063a20173c425d00ba99ea93b25d47feccc72ccee7acdd41ad9aeba48f52f2e88aad632ba1651852d8170bc66d8717ec059c
   languageName: node
   linkType: hard
 
-"@polymer/polymer@patch:@polymer/polymer@3.4.1#./homeassistant-frontend/.yarn/patches/@polymer/polymer/pr-5569.patch::locator=knx-frontend%40workspace%3A.":
-  version: 3.4.1
-  resolution: "@polymer/polymer@patch:@polymer/polymer@npm%3A3.4.1#./homeassistant-frontend/.yarn/patches/@polymer/polymer/pr-5569.patch::version=3.4.1&hash=0f00db&locator=knx-frontend%40workspace%3A."
+"@polymer/polymer@patch:@polymer/polymer@3.5.1#./homeassistant-frontend/.yarn/patches/@polymer/polymer/pr-5569.patch::locator=knx-frontend%40workspace%3A.":
+  version: 3.5.1
+  resolution: "@polymer/polymer@patch:@polymer/polymer@npm%3A3.5.1#./homeassistant-frontend/.yarn/patches/@polymer/polymer/pr-5569.patch::version=3.5.1&hash=0f00db&locator=knx-frontend%40workspace%3A."
   dependencies:
     "@webcomponents/shadycss": ^1.9.1
-  checksum: 3d8ffd3a55808269016785db20758e71e32d17bee45a8055720cefbbef2c24d86939ef743e1416276facab6ef1748b819f9af617a89550293397a27977e7a6d4
+  checksum: b64b5b67592ffe0b1f83a43cfb1457d7213035032f0c3f12a9b9d69bfdd7c94edbe011a30541f419e05869df81bd9a87bfd8ace4b85fd6a975e61e3277607005
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
and apply for 20230601.1

- run `yarn dedupe` when moving to a new tag
- fix resolutions paths instead of having to use manual `resolutionOverride` for each
- add packageManager key