### PR TITLE
Use module variables in `__init__.py` for static values

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,6 @@
 """KNX Frontend."""
+from typing import Final
+
 from .constants import FILE_HASH
 
 
@@ -7,16 +9,11 @@ def locate_dir() -> str:
     return __path__[0]
 
 
-def get_build_id() -> str:
-    """Get the panel build id."""
-    return FILE_HASH
+# Filename of the entrypoint.js to import the panel
+entrypoint_js: Final = f"entrypoint-{FILE_HASH}.js"
 
+# The webcomponent name that loads the panel (main.ts)
+webcomponent_name: Final = "knx-frontend"
 
-def is_dev_build() -> bool:
-    """Check if this is a dev build."""
-    return FILE_HASH == "dev"
-
-
-def entrypoint_js() -> str:
-    """Return the name of the entrypoint js file."""
-    return f"entrypoint-{FILE_HASH}.js"
+is_dev_build: Final = FILE_HASH == "dev"
+is_prod_build: Final = not is_dev_build


### PR DESCRIPTION
These are marked `Final` now and don't need to be called (`entrypoint_js` instead of `entrypoint_js()`) which looks cleaner and is less error prone.

Also added `webcomponent_name` as this should live in the panel package instead of the integration.

closes #77 

example use:
```py
import knx_frontend as knx_panel

    if DOMAIN not in hass.data.get("frontend_panels", {}):
        hass.http.register_static_path(
            URL_BASE,
            path=knx_panel.locate_dir(),
            cache_headers=knx_panel.is_prod_build,
        )
        await panel_custom.async_register_panel(
            hass=hass,
            frontend_url_path=DOMAIN,
            webcomponent_name=knx_panel.webcomponent_name,
            sidebar_title=DOMAIN.upper(),
            sidebar_icon="mdi:bus-electric",
            module_url=f"{URL_BASE}/{knx_panel.entrypoint_js}",
            embed_iframe=True,
            require_admin=True,
        )