### PR TITLE
GM Info dialog: Hide value and payload when null

### DIFF
--- a/src/dialogs/knx-telegram-info-dialog.ts
+++ b/src/dialogs/knx-telegram-info-dialog.ts
@@ -74,14 +74,18 @@ class TelegramInfoDialog extends LitElement {
             <div>${this.telegram.telegramtype}</div>
             <div>${TelegramDictFormatter.dptNameNumber(this.telegram)}</div>
           </div>
-          <div class="row">
-            <div>${this.knx.localize("group_monitor_value")}</div>
-            <div>${TelegramDictFormatter.valueWithUnit(this.telegram)}</div>
-          </div>
-          <div class="row">
-            <div>${this.knx.localize("group_monitor_payload")}</div>
-            <div>${TelegramDictFormatter.payload(this.telegram)}</div>
-          </div>
+          ${this.telegram.value != null
+            ? html` <div class="row">
+                <div>${this.knx.localize("group_monitor_value")}</div>
+                <div>${TelegramDictFormatter.valueWithUnit(this.telegram)}</div>
+              </div>`
+            : nothing}
+          ${this.telegram.payload != null
+            ? html` <div class="row">
+                <div>${this.knx.localize("group_monitor_payload")}</div>
+                <div>${TelegramDictFormatter.payload(this.telegram)}</div>
+              </div>`
+            : nothing}
         </div>
       </div>
       <mwc-button


### PR DESCRIPTION
eg. GroupValueRead has no value and payload - so we don't need to render these rows. Same for telegrams we have no value for, but only a payload.