### PR TITLE
Increase column width for telegram direction

### DIFF
--- a/src/views/group_monitor.ts
+++ b/src/views/group_monitor.ts
@@ -84,7 +84,7 @@ export class KNXGroupMonitor extends LitElement {
           hidden: this.narrow,
           filterable: true,
           title: html`${this.knx.localize("group_monitor_direction")}`,
-          width: "90px",
+          width: "120px",
         },
         sourceAddress: {
           filterable: true,


### PR DESCRIPTION
Currently in German (and possibly also other long languages) the text for the telegram direction gets cut off and there is more than enough space around it to make the column wider.

Only downside is on mobile, but for that use case the table should anyway be enhanced to then display rows that use two lines (as the HA frontend in general does).

![image](https://github.com/XKNX/knx-frontend/assets/114137/68261a85-cf26-4c3f-ac8c-1a76f62905b8)
