### PR TITLE
Hide entity-editor device-tree on narrow screens

### DIFF
--- a/src/views/entities_create.ts
+++ b/src/views/entities_create.ts
@@ -358,6 +358,12 @@ export class KNXCreateEntity extends LitElement {
         max-width: 720px;
       }
 
+      @media screen and (max-width: 600px) {
+        .panel {
+          display: none;
+        }
+      }
+
       .content {
         display: flex;
         flex-direction: row;


### PR DESCRIPTION
This should hide the device tree for most mobile phones in portrait orientation, but still show it in landscape orientation.

related: https://github.com/home-assistant/core/issues/123262