### PR TITLE
Hide "Project" tab when user has not uploaded an ETS project

### DIFF
--- a/src/knx-router.ts
+++ b/src/knx-router.ts
@@ -92,13 +92,13 @@ export class KnxRouter extends HassRouterPage {
   };
 
   protected updatePageEl(el) {
+    logger.debug(`Current Page: ${this._currentPage} Route: ${this.route.path}`);
+
     el.hass = this.hass;
     el.knx = this.knx;
     el.route = this.routeTail;
     el.narrow = this.narrow;
-    el.tabs = knxMainTabs(this.knx.hasProject);
-
-    logger.debug(`Current Page: ${this._currentPage} Route: ${this.route.path}`);
+    el.tabs = knxMainTabs(!!this.knx.info.project);
   }
 }
 

--- a/src/knx-router.ts
+++ b/src/knx-router.ts
@@ -1,5 +1,5 @@
 import { mdiNetwork, mdiFolderMultipleOutline, mdiFileTreeOutline } from "@mdi/js";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 
 import { HassRouterPage, RouterOptions } from "@ha/layouts/hass-router-page";
 import { PageNavigation } from "@ha/layouts/hass-tabs-subpage";
@@ -12,7 +12,7 @@ const logger = new KNXLogger("router");
 
 export const BASE_URL: string = "/knx";
 
-export const knxMainTabs: PageNavigation[] = [
+const knxMainTabs = (hasProject: boolean): PageNavigation[] => [
   {
     translationKey: "info_title",
     path: `${BASE_URL}/info`,
@@ -23,11 +23,15 @@ export const knxMainTabs: PageNavigation[] = [
     path: `${BASE_URL}/group_monitor`,
     iconPath: mdiNetwork,
   },
-  {
-    translationKey: "project_view_title",
-    path: `${BASE_URL}/project`,
-    iconPath: mdiFileTreeOutline,
-  },
+  ...(hasProject
+    ? [
+        {
+          translationKey: "project_view_title",
+          path: `${BASE_URL}/project`,
+          iconPath: mdiFileTreeOutline,
+        },
+      ]
+    : []),
   {
     translationKey: "entities_view_title",
     path: `${BASE_URL}/entities`,
@@ -44,9 +48,6 @@ export class KnxRouter extends HassRouterPage {
   @property({ attribute: false }) public route!: Route;
 
   @property({ type: Boolean }) public narrow!: boolean;
-
-  // at later point could dynamically add and delete tabs
-  @state() private _tabs: PageNavigation[] = knxMainTabs;
 
   protected routerOptions: RouterOptions = {
     defaultPage: "info",
@@ -95,7 +96,7 @@ export class KnxRouter extends HassRouterPage {
     el.knx = this.knx;
     el.route = this.routeTail;
     el.narrow = this.narrow;
-    el.tabs = this._tabs;
+    el.tabs = knxMainTabs(this.knx.hasProject);
 
     logger.debug(`Current Page: ${this._currentPage} Route: ${this.route.path}`);
   }

--- a/src/knx.ts
+++ b/src/knx.ts
@@ -17,17 +17,21 @@ export class knxElement extends ProvideHassLitMixin(LitElement) {
   @property({ attribute: false }) public knx!: KNX;
 
   protected async _initKnx() {
-    const knxConfigEntry = await getConfigEntries(this.hass, { domain: "knx" })[0]; // single instance allowed for knx config
-    const hasProject = !!(await getKnxInfoData(this.hass)).project;
-    this.knx = {
-      language: this.hass.language,
-      config_entry: knxConfigEntry,
-      localize: (string, replace) => localize(this.hass, string, replace),
-      log: new KNXLogger(),
-      hasProject: hasProject,
-      project: null,
-      loadProject: () => this._loadProjectPromise(),
-    };
+    try {
+      const knxConfigEntry = await getConfigEntries(this.hass, { domain: "knx" })[0]; // single instance allowed for knx config
+      const knxInfo = await getKnxInfoData(this.hass);
+      this.knx = {
+        language: this.hass.language,
+        config_entry: knxConfigEntry,
+        localize: (string, replace) => localize(this.hass, string, replace),
+        log: new KNXLogger(),
+        info: knxInfo,
+        project: null,
+        loadProject: () => this._loadProjectPromise(),
+      };
+    } catch (err) {
+      new KNXLogger().error("Failed to initialize KNX", err);
+    }
   }
 
   private _loadProjectPromise(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,9 @@
-import { LitElement, css, html, nothing } from "lit";
+import { LitElement, css, html } from "lit";
 import { customElement, property } from "lit/decorators";
 
 import { applyThemesOnElement } from "@ha/common/dom/apply_themes_on_element";
 import { fireEvent } from "@ha/common/dom/fire_event";
 import { mainWindow } from "@ha/common/dom/get_main_window";
-import "@ha/components/ha-top-app-bar-fixed";
-import "@ha/components/ha-menu-button";
-import "@ha/components/ha-tabs";
 import { listenMediaQuery } from "@ha/common/dom/media_query";
 import { computeRTL, computeDirectionStyles } from "@ha/common/util/compute_rtl";
 import { navigate } from "@ha/common/navigate";
@@ -74,7 +71,7 @@ class KnxFrontend extends knxElement {
 
   protected render() {
     if (!this.hass || !this.knx) {
-      return nothing;
+      return html`<p>Loading...</p>`;
     }
 
     return html`

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,13 @@ import "./knx-router";
 import { KNX } from "./types/knx";
 import { LocationChangedEvent } from "./types/navigation";
 
+declare global {
+  // for fire event
+  interface HASSDomEvents {
+    "knx-reload": undefined;
+  }
+}
+
 @customElement("knx-frontend")
 class KnxFrontend extends knxElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -37,6 +44,11 @@ class KnxFrontend extends knxElement {
       this._initKnx();
     }
     this.addEventListener("knx-location-changed", (e) => this._setRoute(e as LocationChangedEvent));
+
+    this.addEventListener("knx-reload", (_) => {
+      this.knx.log.debug("Reloading KNX object");
+      this._initKnx();
+    });
 
     computeDirectionStyles(computeRTL(this.hass), this.parentElement as LitElement);
 

--- a/src/types/knx.ts
+++ b/src/types/knx.ts
@@ -6,6 +6,7 @@ export interface KNX {
   config_entry: ConfigEntry;
   localize(string: string, replace?: Record<string, any>): string;
   log: any;
+  hasProject: boolean;
   project: KNXProjectRespone | null;
   loadProject(): Promise<void>;
 }

--- a/src/types/knx.ts
+++ b/src/types/knx.ts
@@ -1,12 +1,12 @@
 import { ConfigEntry } from "@ha/data/config_entries";
-import { KNXProjectRespone } from "./websocket";
+import { KNXInfoData, KNXProjectRespone } from "./websocket";
 
 export interface KNX {
   language: string;
   config_entry: ConfigEntry;
   localize(string: string, replace?: Record<string, any>): string;
   log: any;
-  hasProject: boolean;
+  info: KNXInfoData;
   project: KNXProjectRespone | null;
   loadProject(): Promise<void>;
 }

--- a/src/views/info.ts
+++ b/src/views/info.ts
@@ -2,6 +2,7 @@ import { mdiFileUpload } from "@mdi/js";
 import { css, nothing, html, LitElement, TemplateResult, CSSResultGroup } from "lit";
 import { customElement, property, state } from "lit/decorators";
 
+import { fireEvent } from "@ha/common/dom/fire_event";
 import { navigate } from "@ha/common/navigate";
 import "@ha/components/ha-card";
 import "@ha/layouts/hass-tabs-subpage";
@@ -250,6 +251,7 @@ export class KNXInfo extends LitElement {
         this._projectPassword = undefined;
       }
       this._uploading = false;
+      fireEvent(this, "knx-reload");
       this.loadKnxInfo();
     }
   }
@@ -271,6 +273,7 @@ export class KNXInfo extends LitElement {
         text: extractApiErrorMessage(err),
       });
     } finally {
+      fireEvent(this, "knx-reload");
       this.loadKnxInfo();
     }
   }


### PR DESCRIPTION
- Show project tab only when project is available
- reload KNX object when project is uploaded or deleted
- store KNXInfoData in KNX object to be available globally - and not load it in info tab

closes #156