### PR TITLE
Collapsible sections in entity configuration 

### DIFF
--- a/src/components/knx-configure-entity-options.ts
+++ b/src/components/knx-configure-entity-options.ts
@@ -63,30 +63,26 @@ export const renderConfigureEntityCard = (
         ></ha-selector-text>
       </ha-settings-row>
       <ha-expansion-panel .header=${"Advanced"} outlined>
-        <ha-settings-row narrow>
-          <div slot="heading">Entity settings</div>
-          <div slot="description">Description</div>
-          <ha-selector-select
-            .hass=${hass}
-            .label=${"Entity category"}
-            .helper=${"Leave empty for standard behaviour."}
-            .required=${false}
-            .selector=${{
-              select: {
-                multiple: false,
-                custom_value: false,
-                mode: "dropdown",
-                options: [
-                  { value: "config", label: "Config" },
-                  { value: "diagnostic", label: "Diagnostic" },
-                ],
-              },
-            }}
-            .key=${"entity_category"}
-            .value=${config.entity_category}
-            @value-changed=${updateConfig}
-          ></ha-selector-select>
-        </ha-settings-row>
+        <ha-selector-select
+          .hass=${hass}
+          .label=${"Entity category"}
+          .helper=${"Leave empty for standard behaviour."}
+          .required=${false}
+          .selector=${{
+            select: {
+              multiple: false,
+              custom_value: false,
+              mode: "dropdown",
+              options: [
+                { value: "config", label: "Config" },
+                { value: "diagnostic", label: "Diagnostic" },
+              ],
+            },
+          }}
+          .key=${"entity_category"}
+          .value=${config.entity_category}
+          @value-changed=${updateConfig}
+        ></ha-selector-select>
       </ha-expansion-panel>
     </ha-card>
   `;

--- a/src/components/knx-configure-entity.ts
+++ b/src/components/knx-configure-entity.ts
@@ -91,6 +91,14 @@ export class KNXConfigureEntity extends LitElement {
   }
 
   _generateSettingsGroup(group: SettingsGroup, errors?: ErrorDescription[]) {
+    if (group.collapsible === true) {
+      return html` <ha-expansion-panel
+        outlined
+        .header=${group.heading}
+        .secondary=${group.description}
+        >${this._generateItems(group.selectors, errors)}
+      </ha-expansion-panel>`;
+    }
     return html` <ha-settings-row narrow>
       <div slot="heading">${group.heading}</div>
       <div slot="description">${group.description}</div>
@@ -245,7 +253,18 @@ export class KNXConfigureEntity extends LitElement {
         }
       }
 
+      ha-expansion-panel {
+        margin-bottom: 16px;
+      }
+      ha-expansion-panel > :first-child {
+        margin-top: 16px;
+      }
+      ha-expansion-panel > ha-settings-row:first-child {
+        border: 0;
+      }
+
       ha-settings-row {
+        margin-bottom: 16px;
         padding: 0;
       }
       ha-control-select {

--- a/src/components/knx-configure-entity.ts
+++ b/src/components/knx-configure-entity.ts
@@ -134,7 +134,7 @@ export class KNXConfigureEntity extends LitElement {
     const knxEntry = knxData[ga_selector.name];
     if (knxEntry.write !== undefined) return true;
     if (knxEntry.state !== undefined) return true;
-    if (knxEntry.passive !== undefined && knxEntry.passive.length) return true;
+    if (knxEntry.passive?.length) return true;
 
     return false;
   }

--- a/src/components/knx-configure-entity.ts
+++ b/src/components/knx-configure-entity.ts
@@ -96,7 +96,7 @@ export class KNXConfigureEntity extends LitElement {
         outlined
         .header=${group.heading}
         .secondary=${group.description}
-        .expanded=${this._group_has_group_address_defined(group)}
+        .expanded=${this._groupHasGroupAddressInConfig(group)}
         >${this._generateItems(group.selectors, errors)}
       </ha-expansion-panel>`;
     }
@@ -107,20 +107,19 @@ export class KNXConfigureEntity extends LitElement {
     </ha-settings-row>`;
   }
 
-  _group_has_group_address_defined(group: SettingsGroup) {
+  _groupHasGroupAddressInConfig(group: SettingsGroup) {
     if (this.config === undefined) {
       return false;
     }
     return group.selectors.some((selector) => {
       if (selector.type === "group_address")
-        return this._has_group_address_defined(selector, this.config!.knx);
+        return this._hasGroupAddressInConfig(selector, this.config!.knx);
       if (selector.type === "group_select")
         return selector.options.some((options) =>
           options.schema.some((schema) => {
-            if (schema.type === "settings_group")
-              return this._group_has_group_address_defined(schema);
+            if (schema.type === "settings_group") return this._groupHasGroupAddressInConfig(schema);
             if (schema.type === "group_address")
-              return this._has_group_address_defined(schema, this.config!.knx);
+              return this._hasGroupAddressInConfig(schema, this.config!.knx);
             return false;
           }),
         );
@@ -128,7 +127,7 @@ export class KNXConfigureEntity extends LitElement {
     });
   }
 
-  _has_group_address_defined(ga_selector: GASchema, knxData: KnxEntityData) {
+  _hasGroupAddressInConfig(ga_selector: GASchema, knxData: KnxEntityData) {
     if (!(ga_selector.name in knxData)) return false;
 
     const knxEntry = knxData[ga_selector.name];

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -23,7 +23,7 @@ export type SelectorSchema =
       helper?: string;
     };
 
-type GASchema = {
+export type GASchema = {
   name: string;
   type: "group_address";
   label?: string;

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -7,6 +7,7 @@ export type SettingsGroup = {
   description: string;
   selectors: SelectorSchema[];
   advanced?: boolean;
+  collapsible?: boolean;
 };
 
 export type SelectorSchema =
@@ -141,6 +142,7 @@ export const lightSchema: SettingsGroup[] = [
     type: "settings_group",
     heading: "Color temperature",
     description: "Control the lights color temperature.",
+    collapsible: true,
     selectors: [
       {
         name: "ga_color_temp",
@@ -206,6 +208,7 @@ export const lightSchema: SettingsGroup[] = [
     type: "settings_group",
     heading: "Color",
     description: "Control the light color.",
+    collapsible: true,
     selectors: [
       {
         type: "group_select",


### PR DESCRIPTION
These default to `expanded` when a group address is defined (edit mode) in any child-field. Otherwise they default `collapsed`.

<img width="878" alt="Bildschirmfoto 2024-10-18 um 00 24 58" src="https://github.com/user-attachments/assets/01e2e720-6f35-40ec-b0f8-97c6d97a3712">
