### PR TITLE
Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "knx_frontend"
-license = { text = "MIT License" }
+license = { text = "MIT" }
 description = "KNX panel for Home Assistant"
 keywords = ["Home Assistant", "KNX"]
 readme = "README.md"


### PR DESCRIPTION
Use official SPDX license identifier as recommended by [PEP 639](https://peps.python.org/pep-0639/).
https://spdx.org/licenses/MIT.html