### PR TITLE
Forward "a", "d" and "m" keyboard shortcuts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ class KnxFrontend extends knxElement {
         // Ignore if modifier keys are pressed
         return;
       }
-      if (["c", "e"].includes(ev.key)) {
+      if (["a", "c", "d", "e", "m"].includes(ev.key)) {
         // @ts-ignore
         fireEvent(mainWindow, "hass-quick-bar-trigger", ev, {
           bubbles: false,


### PR DESCRIPTION
closes #193