### PR TITLE
Extend reset after limit

### DIFF
--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -111,10 +111,10 @@ export const binarySensorSchema: SettingsGroup[] = [
       {
         name: "reset_after",
         type: "selector",
-        selector: { number: {min: 0, max: 600, unit_of_measurement: "s"} },
+        selector: { number: { min: 0, step: 0.1, unit_of_measurement: "s" } },
         label: "Reset after",
         helper: "Reset back to “off” state after specified seconds.",
-        default: 1 , // not forwarded to data when loading - fine when optional: true
+        default: 1, // not forwarded to data when loading - fine when optional: true
         optional: true,
       },
     ],

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -111,10 +111,10 @@ export const binarySensorSchema: SettingsGroup[] = [
       {
         name: "reset_after",
         type: "selector",
-        selector: { number: { min: 0, max: 10, step: 0.1, unit_of_measurement: "s" } },
+        selector: { number: {min: 0, max: 600, unit_of_measurement: "s"} },
         label: "Reset after",
         helper: "Reset back to “off” state after specified seconds.",
-        default: 0.8, // not forwarded to data when loading - fine when optional: true
+        default: 1 , // not forwarded to data when loading - fine when optional: true
         optional: true,
       },
     ],

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -111,7 +111,9 @@ export const binarySensorSchema: SettingsGroup[] = [
       {
         name: "reset_after",
         type: "selector",
-        selector: { number: { min: 0, step: 0.1, unit_of_measurement: "s" } },
+        selector: {
+          number: { min: 0, max: 600, mode: "box", step: 0.1, unit_of_measurement: "s" },
+        },
         label: "Reset after",
         helper: "Reset back to “off” state after specified seconds.",
         default: 1, // not forwarded to data when loading - fine when optional: true


### PR DESCRIPTION
Linked to Issue #210. Removes the upper limit for reset_after parameter.
This converts the slider into a number input box only.


<img width="757" alt="Screenshot 2025-03-08 at 17 29 07" src="https://github.com/user-attachments/assets/7cffed75-e62e-4be7-858d-b3dceb09921a" />
