### PR TITLE
GroupSelect refactor

### DIFF
--- a/src/components/knx-configure-entity-options.ts
+++ b/src/components/knx-configure-entity-options.ts
@@ -15,11 +15,13 @@ import type { BaseEntityData, ErrorDescription } from "../types/entity_data";
 
 export const renderConfigureEntityCard = (
   hass: HomeAssistant,
-  config: Partial<BaseEntityData>,
+  entityConfig: Partial<BaseEntityData>,
   updateConfig: (ev: CustomEvent) => void,
   errors?: ErrorDescription[],
 ) => {
-  const device = config.device_info ? deviceFromIdentifier(hass, config.device_info) : undefined;
+  const device = entityConfig.device_info
+    ? deviceFromIdentifier(hass, entityConfig.device_info)
+    : undefined;
   const deviceName = device ? (device.name_by_user ?? device.name) : "";
   // currently only baseError is possible, others shouldn't be possible due to selectors / optional
   const entityBaseError = errors?.find((err) => (err.path ? err.path.length === 0 : true));
@@ -46,7 +48,7 @@ export const renderConfigureEntityCard = (
           .hass=${hass}
           .key=${"entity.device_info"}
           .helper=${"A device allows to group multiple entities. Select the device this entity belongs to or create a new one."}
-          .value=${config.device_info ?? undefined}
+          .value=${entityConfig.device_info ?? undefined}
           @value-changed=${updateConfig}
         ></knx-device-picker>
         <ha-selector-text
@@ -58,7 +60,7 @@ export const renderConfigureEntityCard = (
             text: { type: "text", prefix: deviceName },
           }}
           .key=${"entity.name"}
-          .value=${config.name}
+          .value=${entityConfig.name}
           @value-changed=${updateConfig}
         ></ha-selector-text>
       </ha-expansion-panel>
@@ -80,7 +82,7 @@ export const renderConfigureEntityCard = (
             },
           }}
           .key=${"entity.entity_category"}
-          .value=${config.entity_category}
+          .value=${entityConfig.entity_category}
           @value-changed=${updateConfig}
         ></ha-selector-select>
       </ha-expansion-panel>

--- a/src/components/knx-configure-entity-options.ts
+++ b/src/components/knx-configure-entity-options.ts
@@ -44,7 +44,7 @@ export const renderConfigureEntityCard = (
       >
         <knx-device-picker
           .hass=${hass}
-          .key=${"device_info"}
+          .key=${"entity.device_info"}
           .helper=${"A device allows to group multiple entities. Select the device this entity belongs to or create a new one."}
           .value=${config.device_info ?? undefined}
           @value-changed=${updateConfig}
@@ -57,7 +57,7 @@ export const renderConfigureEntityCard = (
           .selector=${{
             text: { type: "text", prefix: deviceName },
           }}
-          .key=${"name"}
+          .key=${"entity.name"}
           .value=${config.name}
           @value-changed=${updateConfig}
         ></ha-selector-text>
@@ -79,7 +79,7 @@ export const renderConfigureEntityCard = (
               ],
             },
           }}
-          .key=${"entity_category"}
+          .key=${"entity.entity_category"}
           .value=${config.entity_category}
           @value-changed=${updateConfig}
         ></ha-selector-select>

--- a/src/components/knx-configure-entity.ts
+++ b/src/components/knx-configure-entity.ts
@@ -24,7 +24,7 @@ import { extractValidationErrors } from "../utils/validation";
 import type { EntityData, ErrorDescription } from "../types/entity_data";
 import type { KNX } from "../types/knx";
 import type { PlatformInfo } from "../utils/common";
-import type { SettingsGroup, SelectorSchema, GroupSelect, GASchema } from "../utils/schema";
+import type { SettingsGroup, SelectorSchema, GroupSelect, GASelector } from "../utils/schema";
 
 const logger = new KNXLogger("knx-configure-entity");
 
@@ -165,7 +165,7 @@ export class KNXConfigureEntity extends LitElement {
     });
   }
 
-  private _hasGroupAddressInConfig(ga_selector: GASchema, path: string) {
+  private _hasGroupAddressInConfig(ga_selector: GASelector, path: string) {
     const gaData = this._getNestedValue(path + "." + ga_selector.name);
     if (!gaData) return false;
     if (gaData.write !== undefined) return true;

--- a/src/components/knx-configure-entity.ts
+++ b/src/components/knx-configure-entity.ts
@@ -55,8 +55,8 @@ export class KNXConfigureEntity extends LitElement {
       // would set this.conifg.knx.ga_sensor.state to "0/1/4"
       // TODO: this is not checked against any schema
       const urlParams = new URLSearchParams(mainWindow.location.search);
-      this._url_suggestions = Object.fromEntries(urlParams.entries());
-      for (const [path, value] of Object.entries(this._url_suggestions)) {
+      const url_suggestions = Object.fromEntries(urlParams.entries());
+      for (const [path, value] of Object.entries(url_suggestions)) {
         this._setNestedValue(path, value);
         fireEvent(this, "knx-entity-configuration-changed", this.config);
       }

--- a/src/components/knx-configure-entity.ts
+++ b/src/components/knx-configure-entity.ts
@@ -70,6 +70,7 @@ export class KNXConfigureEntity extends LitElement {
     let current = this.config!;
     for (const key of keys) {
       if (!(key in current)) {
+        if (value === undefined) return; // don't create to remove
         current[key] = {};
       }
       current = current[key];
@@ -85,8 +86,6 @@ export class KNXConfigureEntity extends LitElement {
 
   private _getNestedValue(path: string) {
     const keys = path.split(".");
-    const keysTail = keys.pop();
-    if (!keysTail) return undefined;
     let current = this.config!;
     for (const key of keys) {
       if (!(key in current)) {
@@ -94,7 +93,7 @@ export class KNXConfigureEntity extends LitElement {
       }
       current = current[key];
     }
-    return current[keysTail];
+    return current;
   }
 
   protected render(): TemplateResult {
@@ -250,13 +249,10 @@ export class KNXConfigureEntity extends LitElement {
 
   private _getOptionIndex(selector: GroupSelect, groupPath: string): number {
     // check if sub-schema is in this.config
-    const keys = groupPath.split(".");
-    let configFragment = this.config!;
-    for (const key of keys) {
-      if (!(key in configFragment)) {
-        return 0; // default to first option if key is not in config
-      }
-      configFragment = configFragment[key];
+    const configFragment = this._getNestedValue(groupPath);
+    if (configFragment === undefined) {
+      logger.debug("No config found for group select", groupPath);
+      return 0; // Fallback to first option if key is not in config
     }
     // get non-optional subkeys for each groupSelect schema by index
     // get index of first option that has all keys in config

--- a/src/components/knx-group-address-selector.ts
+++ b/src/components/knx-group-address-selector.ts
@@ -4,6 +4,7 @@ import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state, query, queryAll } from "lit/decorators";
 import { classMap } from "lit/directives/class-map";
 import { consume } from "@lit-labs/context";
+import memoize from "memoize-one";
 
 import "@ha/components/ha-list-item";
 import "@ha/components/ha-selector/ha-selector-select";
@@ -16,7 +17,7 @@ import type { DragDropContext } from "../utils/drag-drop-context";
 import { dragDropContext } from "../utils/drag-drop-context";
 import { isValidDPT } from "../utils/dpt";
 import { extractValidationErrors } from "../utils/validation";
-import type { GASelectorOptions } from "../utils/schema";
+import type { GASelectorOptions, DPTOption } from "../utils/schema";
 import type { KNX } from "../types/knx";
 import type { DPT, GroupAddress } from "../types/websocket";
 import type { ErrorDescription, GASchema } from "../types/entity_data";
@@ -49,6 +50,8 @@ export class GroupAddressSelector extends LitElement {
 
   @state() private _showPassive = false;
 
+  private _selectedDPTValue?: string;
+
   validGroupAddresses: GroupAddress[] = [];
 
   filteredGroupAddresses: GroupAddress[] = [];
@@ -73,11 +76,16 @@ export class GroupAddressSelector extends LitElement {
       : [];
   }
 
-  getValidDptFromConfigValue(): DPT | undefined {
-    return this.config.dpt
-      ? this.options.dptSelect?.find((dpt) => dpt.value === this.config.dpt)?.dpt
-      : undefined;
+  getDptOptionByValue(value: string | undefined): DPTOption | undefined {
+    return value ? this.options.dptSelect?.find((dpt) => dpt.value === value) : undefined;
   }
+
+  setFilteredGroupAddresses = memoize((dpt: DPT | undefined) => {
+    this.filteredGroupAddresses = dpt
+      ? this.getValidGroupAddresses([dpt])
+      : this.validGroupAddresses;
+    this.addressOptions = getAddressOptions(this.filteredGroupAddresses);
+  });
 
   connectedCallback() {
     super.connectedCallback();
@@ -95,13 +103,10 @@ export class GroupAddressSelector extends LitElement {
 
   protected willUpdate(changedProps: PropertyValues<this>) {
     if (changedProps.has("config")) {
-      const selectedDPT = this.getValidDptFromConfigValue();
-      if (changedProps.get("config")?.dpt !== this.config.dpt) {
-        this.filteredGroupAddresses = selectedDPT
-          ? this.getValidGroupAddresses([selectedDPT])
-          : this.validGroupAddresses;
-        this.addressOptions = getAddressOptions(this.filteredGroupAddresses);
-      }
+      this._selectedDPTValue = this.config.dpt ?? this._selectedDPTValue;
+      const selectedDPT = this.getDptOptionByValue(this._selectedDPTValue)?.dpt;
+      this.setFilteredGroupAddresses(selectedDPT);
+
       if (selectedDPT && this.knx.project?.project_loaded) {
         const allDpts = [
           this.config.write,
@@ -226,7 +231,7 @@ export class GroupAddressSelector extends LitElement {
       .key=${"dpt"}
       .label=${"Datapoint type"}
       .options=${this.options.dptSelect}
-      .value=${this.config.dpt}
+      .value=${this._selectedDPTValue}
       .disabled=${this.dptSelectorDisabled}
       .invalid=${!!invalid}
       .invalidMessage=${invalid?.error_message}
@@ -240,42 +245,58 @@ export class GroupAddressSelector extends LitElement {
     const target = ev.target as any;
     const value = ev.detail.value;
     const newConfig = { ...this.config, [target.key]: value };
-    this._updateDptSelector(target.key, newConfig);
+    const hasGroupAddresses = !!(newConfig.write || newConfig.state || newConfig.passive?.length);
+
+    this._updateDptSelector(target.key, newConfig, hasGroupAddresses);
     this.config = newConfig;
-    fireEvent(this, "value-changed", { value: this.config });
+
+    const newValue = hasGroupAddresses ? newConfig : undefined;
+    fireEvent(this, "value-changed", { value: newValue });
     this.requestUpdate();
   }
 
-  private _updateDptSelector(targetKey: string, newConfig: GASchema) {
-    if (!(this.options.dptSelect && this.knx.project?.project_loaded)) return;
+  private _updateDptSelector(targetKey: string, newConfig: GASchema, hasGroupAddresses: boolean) {
     // updates newConfig in place
-    let newGa: string | undefined;
-    if (targetKey === "write" || targetKey === "state") {
-      newGa = newConfig[targetKey];
-    } else if (targetKey === "passive") {
-      // for passive ignore removals, only use additions
-      const addedGa = newConfig.passive?.filter((ga) => !this.config.passive?.includes(ga))?.[0];
-      newGa = addedGa;
-    } else {
-      return;
-    }
-    // disable when project is loaded and everything matches -> not here
-    if (!newConfig.write && !newConfig.state && !newConfig.passive?.length) {
-      // when all GAs have been cleared, reset dpt field
+    if (!this.options.dptSelect) return;
+
+    if (targetKey === "dpt") {
+      this._selectedDPTValue = newConfig.dpt;
+    } else if (!hasGroupAddresses) {
+      // when all GAs have actively been cleared, reset dpt field
       newConfig.dpt = undefined;
+      this._selectedDPTValue = undefined;
+      return;
+    } else {
+      newConfig.dpt = this._selectedDPTValue;
     }
-    if (this.config.dpt === undefined) {
-      const newDpt = this.validGroupAddresses.find((ga) => ga.address === newGa)?.dpt;
-      if (!newDpt) return;
-      const exactDptMatch = this.options.dptSelect.find(
-        (dptOption) => dptOption.dpt.main === newDpt.main && dptOption.dpt.sub === newDpt.sub,
-      );
-      const newDptValue = exactDptMatch
-        ? exactDptMatch.value
-        : // fallback to first valid DPT if allowed in options; otherwise undefined
-          this.options.dptSelect.find((dptOption) => isValidDPT(newDpt, [dptOption.dpt]))?.value;
-      newConfig.dpt = newDptValue;
+
+    // below only applies to loaded projects as it inferes DPT from selected group address
+    if (!this.knx.project?.project_loaded) return;
+
+    const newGa = this._getAddedGroupAddress(targetKey, newConfig);
+    if (!newGa || this._selectedDPTValue !== undefined) return;
+
+    const newDpt = this.validGroupAddresses.find((ga) => ga.address === newGa)?.dpt;
+    if (!newDpt) return;
+
+    const exactDptMatch = this.options.dptSelect.find(
+      (dptOption) => dptOption.dpt.main === newDpt.main && dptOption.dpt.sub === newDpt.sub,
+    );
+    newConfig.dpt = exactDptMatch
+      ? exactDptMatch.value
+      : // fallback to first valid DPT if allowed in options; otherwise undefined
+        this.options.dptSelect.find((dptOption) => isValidDPT(newDpt, [dptOption.dpt]))?.value;
+  }
+
+  private _getAddedGroupAddress(targetKey: string, newConfig: GASchema): string | undefined {
+    if (targetKey === "write" || targetKey === "state") {
+      return newConfig[targetKey];
     }
+    if (targetKey === "passive") {
+      // for passive ignore removals, only use additions
+      return newConfig.passive?.find((ga) => !this.config.passive?.includes(ga));
+    }
+    return undefined;
   }
 
   private _togglePassiveVisibility(ev: CustomEvent) {

--- a/src/components/knx-group-address-selector.ts
+++ b/src/components/knx-group-address-selector.ts
@@ -16,7 +16,7 @@ import type { DragDropContext } from "../utils/drag-drop-context";
 import { dragDropContext } from "../utils/drag-drop-context";
 import { isValidDPT } from "../utils/dpt";
 import { extractValidationErrors } from "../utils/validation";
-import type { GASchemaOptions } from "../utils/schema";
+import type { GASelectorOptions } from "../utils/schema";
 import type { KNX } from "../types/knx";
 import type { DPT, GroupAddress } from "../types/websocket";
 import type { ErrorDescription, GASchema } from "../types/entity_data";
@@ -41,7 +41,7 @@ export class GroupAddressSelector extends LitElement {
 
   @property({ attribute: false }) public config: GASchema = {};
 
-  @property({ attribute: false }) public options!: GASchemaOptions;
+  @property({ attribute: false }) public options!: GASelectorOptions;
 
   @property({ reflect: true }) public key!: string;
 

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -19,7 +19,6 @@ export interface GroupSelect {
   type: "group_select";
   name: string;
   options: {
-    value: string;
     label: string;
     description?: string;
     schema: (SettingsGroup | SelectorSchema)[];
@@ -450,7 +449,6 @@ export const lightSchema: SettingsGroup[] = [
           {
             label: "Single address",
             description: "RGB, RGBW or XYY color controlled by a single group address",
-            value: "default",
             schema: [
               {
                 name: "ga_color",
@@ -486,7 +484,6 @@ export const lightSchema: SettingsGroup[] = [
           {
             label: "Individual addresses",
             description: "RGB(W) using individual state and brightness group addresses",
-            value: "individual",
             schema: [
               {
                 type: "settings_group",
@@ -611,7 +608,6 @@ export const lightSchema: SettingsGroup[] = [
           {
             label: "HSV",
             description: "Hue, saturation and brightness using individual group addresses",
-            value: "hsv",
             schema: [
               {
                 type: "settings_group",

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -15,6 +15,17 @@ export type SelectorSchema =
   | { name: "sync_state"; type: "sync_state" }
   | KnxHaSelector;
 
+export interface GroupSelect {
+  type: "group_select";
+  name: string;
+  options: {
+    value: string;
+    label: string;
+    description?: string;
+    schema: (SettingsGroup | SelectorSchema)[];
+  }[];
+}
+
 export interface KnxHaSelector {
   name: string;
   type: "selector";
@@ -45,17 +56,6 @@ export interface DPTOption {
   label: string;
   description?: string;
   dpt: DPT;
-}
-
-export interface GroupSelect {
-  type: "group_select";
-  name: string;
-  options: {
-    value: string;
-    label: string;
-    description?: string;
-    schema: (SettingsGroup | SelectorSchema)[];
-  }[];
 }
 
 export const binarySensorSchema: SettingsGroup[] = [

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -10,7 +10,7 @@ export interface SettingsGroup {
 }
 
 export type SelectorSchema =
-  | GASchema
+  | GASelector
   | GroupSelect
   | { name: "sync_state"; type: "sync_state" }
   | KnxHaSelector;
@@ -35,14 +35,14 @@ export interface KnxHaSelector {
   helper?: string;
 }
 
-export interface GASchema {
+export interface GASelector {
   name: string;
   type: "group_address";
   label?: string;
-  options: GASchemaOptions;
+  options: GASelectorOptions;
 }
 
-export interface GASchemaOptions {
+export interface GASelectorOptions {
   write?: { required: boolean };
   state?: { required: boolean };
   passive?: boolean;

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -444,7 +444,7 @@ export const lightSchema: SettingsGroup[] = [
     selectors: [
       {
         type: "group_select",
-        name: "_light_color_mode_schema",
+        name: "color",
         options: [
           {
             label: "Single address",


### PR DESCRIPTION
This changes schema with sub-groups from needing a helper key-value to sub-key style. The sub-key can have its own validation in the backend then. 

### Example:

Previous:
```json
"knx": {
  "color_temp_min": 2700,
  "color_temp_max": 6000,
  "ga_switch": {
    "write": "1/1/21",
    "state": "1/0/21",
    "passive": []
  },
  "_light_color_mode_schema": "default",
  "ga_color": {
    "write": "0/6/4",
    "state": "0/6/5",
    "passive": [],
    "dpt": "251.600",
  },
  "sync_state": true
}
```

New:

```json
"knx": {
  "color_temp_min": 2700,
  "color_temp_max": 6000,
  "ga_switch": {
    "write": "1/1/21",
    "state": "1/0/21",
    "passive": []
  },
  "color": {
    "ga_color": {
      "write": "0/6/4",
      "state": "0/6/5",
      "passive": [],
      "dpt": "251.600",
    },
  },
  "sync_state": true
}
```

Should fix #185