### PR TITLE
Extend Group Monitor with URL filtering

### DIFF
--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -50,6 +50,9 @@
   "project_view_table_description": "Beschreibung",
   "project_view_table_dpt": "DPT",
   "project_view_table_updated": "Aktualisiert",
+  "project_view_menu_view_telegrams": "Telegramme anzeigen",
+  "project_view_menu_create_binary_sensor": "Binärsensor erstellen",
+  "entities_view_monitor_telegrams": "Telegramme überwachen",
   "Incoming": "Eingehend",
   "Outgoing": "Ausgehend",
 

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -51,6 +51,9 @@
   "project_view_table_dpt": "DPT",
   "project_view_table_updated": "Updated",
   "project_view_add_switch": "Add switch",
+  "project_view_menu_view_telegrams": "View telegrams",
+  "project_view_menu_create_binary_sensor": "Create binary sensor",
+  "entities_view_monitor_telegrams": "Monitor telegrams",
   "Incoming": "Incoming",
   "Outgoing": "Outgoing",
 

--- a/src/views/group_monitor.ts
+++ b/src/views/group_monitor.ts
@@ -492,6 +492,7 @@ export class KNXGroupMonitor extends LitElement {
   /** Clears all active filters */
   private _handleClearFilters(): void {
     this._filters = {};
+    this._updateUrlFromFilters();
   }
 
   /**

--- a/src/views/group_monitor.ts
+++ b/src/views/group_monitor.ts
@@ -762,7 +762,8 @@ export class KNXGroupMonitor extends LitElement {
       : `${this.route.prefix}${this.route.path}`;
 
     // Update URL without triggering navigation
-    navigate(newPath, { replace: true });
+    // Decode URL for better readability
+    navigate(decodeURIComponent(newPath), { replace: true });
   }
 
   /** Sets filters from URL query parameters */

--- a/src/views/group_monitor.ts
+++ b/src/views/group_monitor.ts
@@ -237,8 +237,6 @@ export class KNXGroupMonitor extends LitElement {
    * Sets filters from URL parameters whenever the route changes
    */
   public willUpdate(changedProperties: Map<string | number | symbol, unknown>): void {
-    super.willUpdate(changedProperties);
-
     // Initialize filters from URL when route changes
     if (changedProperties.has("route") && this.route) {
       this._setFiltersFromUrl();

--- a/src/views/group_monitor.ts
+++ b/src/views/group_monitor.ts
@@ -64,7 +64,7 @@ interface TelegramDistinctValues {
 const logger = new KNXLogger("group_monitor");
 
 // Maximum number of telegrams to keep in local storage (ring buffer)
-const MAX_TELEGRAM_STORAGE = 5000;
+const MAX_TELEGRAM_STORAGE = 30000;
 
 /**
  * KNX Group Monitor Component
@@ -75,7 +75,7 @@ const MAX_TELEGRAM_STORAGE = 5000;
  * - Sortable data table with detailed telegram information
  * - Navigation between telegrams with detailed view dialog
  * - Historical telegram loading and management
- * - Ring buffer storage with 5,000 telegram limit for performance optimization
+ * - Ring buffer storage with 30,000 telegram limit
  * - Smart refresh that merges new telegrams with existing cache (no data loss)
  * - URL-based filtering for deep linking and to persist filter combinations
  *

--- a/src/views/project_view.ts
+++ b/src/views/project_view.ts
@@ -1,4 +1,4 @@
-import { mdiFilterVariant, mdiPlus } from "@mdi/js";
+import { mdiFilterVariant, mdiPlus, mdiMathLog } from "@mdi/js";
 import type { TemplateResult } from "lit";
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
@@ -170,12 +170,22 @@ export class KNXProjectView extends LitElement {
     };
   });
 
-  private _groupAddressMenu(groupAddress: GroupAddress): TemplateResult | typeof nothing {
+  private _groupAddressMenu(groupAddress: GroupAddress): TemplateResult {
     const items: IconOverflowMenuItem[] = [];
+
+    // Add menu item to view telegrams for this group address
+    items.push({
+      path: mdiMathLog,
+      label: this.knx.localize("project_view_menu_view_telegrams"),
+      action: () => {
+        navigate(`/knx/group_monitor?destination=${groupAddress.address}`);
+      },
+    });
+
     if (groupAddress.dpt?.main === 1) {
       items.push({
         path: mdiPlus,
-        label: "Create binary sensor",
+        label: this.knx.localize("project_view_menu_create_binary_sensor"),
         action: () => {
           navigate(
             "/knx/entities/create/binary_sensor?knx.ga_sensor.state=" + groupAddress.address,
@@ -184,11 +194,9 @@ export class KNXProjectView extends LitElement {
       });
     }
 
-    return items.length
-      ? html`
-          <ha-icon-overflow-menu .hass=${this.hass} narrow .items=${items}> </ha-icon-overflow-menu>
-        `
-      : nothing;
+    return html`
+      <ha-icon-overflow-menu .hass=${this.hass} narrow .items=${items}> </ha-icon-overflow-menu>
+    `;
   }
 
   private _getRows(visibleGroupAddresses: string[]): GroupAddress[] {


### PR DESCRIPTION
This update enhances the Group Monitor by enabling URL-based filtering of telegrams. It also introduces contextual quick links from the project and entity views that open the Group Monitor with pre-applied filters — making it easier to inspect only the relevant telegrams for a given group address or entity. You can now share or bookmark filtered views to easily preserve and revisit complex filter settings.

