### PR TITLE
Fix group monitor sorting to use microsecond-precision timestamps (closes #234)

### DIFF
--- a/src/dialogs/knx-telegram-info-dialog.ts
+++ b/src/dialogs/knx-telegram-info-dialog.ts
@@ -8,7 +8,7 @@ import "@ha/components/ha-svg-icon";
 import "../components/knx-dialog-header";
 import { mdiArrowLeft, mdiArrowRight, mdiClose } from "@mdi/js";
 
-import { formatDateTimeWithMilliseconds } from "utils/format";
+import { formatDateTimeWithMilliseconds, formatIsoTimestampWithMicroseconds } from "utils/format";
 import type { KNX } from "../types/knx";
 import type { TelegramRow } from "../types/telegram-row";
 import "@ha/components/ha-relative-time";
@@ -99,7 +99,10 @@ class TelegramInfoDialog extends LitElement {
             ${this.knx.localize("knx_telegram_info_dialog_telegram")}
           </div>
           <div slot="subtitle">
-            ${formatDateTimeWithMilliseconds(this.telegram.timestamp) + " "} (<ha-relative-time
+            <span title=${formatIsoTimestampWithMicroseconds(this.telegram.timestampIso)}>
+              ${formatDateTimeWithMilliseconds(this.telegram.timestamp) + " "}
+            </span>
+            (<ha-relative-time
               .hass=${this.hass}
               .datetime=${this.telegram.timestamp}
               .capitalize=${false}

--- a/src/types/telegram-row.ts
+++ b/src/types/telegram-row.ts
@@ -11,6 +11,12 @@ import type { TelegramDict } from "./websocket";
 import { TelegramDictFormatter } from "../utils/format";
 
 /**
+ * Type for TelegramRow property keys
+ * Provides type safety when referencing TelegramRow properties
+ */
+export type TelegramRowKeys = keyof TelegramRow;
+
+/**
  * KNX telegram row model implementing the DataTableRowData interface
  * Transforms raw telegram data into a structured format for table display
  */
@@ -28,8 +34,14 @@ export class TelegramRow implements DataTableRowData {
   id: string;
 
   /**
+   * Original timestamp string as received from the telegram
+   * Preserves the microsecond precision that Date objects do not support
+   */
+  timestampIso: string;
+
+  /**
    * Parsed timestamp when the telegram was captured
-   * Converted from string representation to Date object for processing
+   * Converted from ISO 8601 string to Date object for processing
    */
   timestamp: Date;
 
@@ -184,7 +196,7 @@ export class TelegramRow implements DataTableRowData {
 
     /**
      * Generate unique identifier from timestamp and address components
-     * Combines multiple fields to minimize collision risk in large datasets
+     * Combines multiple fields to minimize collision risk
      * Format: "timestamp_source_destination" (sanitized)
      */
     this.id = [
@@ -196,6 +208,9 @@ export class TelegramRow implements DataTableRowData {
     // ============================================================================
     // Timestamp Processing
     // ============================================================================
+
+    /** Store original timestamp string for reference */
+    this.timestampIso = telegram.timestamp;
 
     /** Convert timestamp string to Date object for proper date/time handling */
     this.timestamp = new Date(telegram.timestamp);

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -95,6 +95,38 @@ export const formatDateTimeWithMilliseconds = (date: Date): string =>
   });
 
 /**
+ * Format an ISO timestamp string to a date and time string with microsecond precision.
+ *
+ * @param timestampIso - The ISO timestamp string containing microsecond precision
+ * @returns Formatted date and time string with microsecond precision
+ */
+export const formatIsoTimestampWithMicroseconds = (timestampIso: string): string => {
+  // Create Date object from ISO timestamp
+  const date = new Date(timestampIso);
+
+  // Extract microseconds from ISO timestamp (format: YYYY-MM-DDTHH:MM:SS.ffffff)
+  const microsecondMatch = timestampIso.match(/\.(\d{6})/);
+  const microseconds = microsecondMatch ? microsecondMatch[1] : "000000";
+
+  return (
+    date.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }) +
+    ", " +
+    date.toLocaleTimeString(undefined, {
+      hour12: false,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }) +
+    "." +
+    microseconds
+  );
+};
+
+/**
  * Format a Date object representing a time offset to MM:SS.MMM format.
  *
  * @param offset - The Date object containing the time difference

--- a/src/views/group_monitor.ts
+++ b/src/views/group_monitor.ts
@@ -28,7 +28,7 @@ import { mdiDeleteSweep, mdiFastForward, mdiPause, mdiRefresh } from "@mdi/js";
 import { formatTimeWithMilliseconds, formatOffset } from "utils/format";
 import { subscribeKnxTelegrams, getGroupMonitorInfo } from "../services/websocket.service";
 import { KNXLogger } from "../tools/knx-logger";
-import { TelegramRow } from "../types/telegram-row";
+import { TelegramRow, type TelegramRowKeys } from "../types/telegram-row";
 import type { ToggleFilterEvent } from "../components/data-table/cell/knx-table-cell-filterable";
 
 import type { KNX } from "../types/knx";
@@ -192,7 +192,7 @@ export class KNXGroupMonitor extends LitElement {
           return telegram.cachedRow;
         });
 
-      if (sortColumn === "timestamp") {
+      if (sortColumn === ("timestampIso" as TelegramRowKeys)) {
         this._calculateRelativeTimeOffsets(rows);
       }
 
@@ -810,7 +810,7 @@ export class KNXGroupMonitor extends LitElement {
       _language: string,
     ): DataTableColumnContainer<TelegramRow> => ({
       // Timestamp column with relative time offsets when sorting by time
-      timestamp: {
+      ["timestampIso" as TelegramRowKeys]: {
         showNarrow: false,
         filterable: true,
         sortable: true,
@@ -821,7 +821,7 @@ export class KNXGroupMonitor extends LitElement {
         template: (row) => html`
           <knx-table-cell>
             <div class="primary" slot="primary">${formatTimeWithMilliseconds(row.timestamp)}</div>
-            ${row.offset.getTime() >= 0 && this._sortColumn === "timestamp"
+            ${row.offset.getTime() >= 0 && this._sortColumn === ("timestampIso" as TelegramRowKeys)
               ? html`
                   <div class="secondary" slot="secondary">
                     <span style="margin-right: 2px;">+</span>


### PR DESCRIPTION
This change addresses an issue where multiple telegrams arriving within the same millisecond could be mis-ordered. Previously, the Group Monitor relied on JavaScript’s Date object for sorting, which only offers millisecond precision. When two or more telegrams shared the same millisecond timestamp, their relative order could “collide” and render incorrectly.

With this PR, Group Monitor now use the ISO-8601 timestamp string provided by our backend—which includes microsecond precision—instead of the Date object.