### PR TITLE
Fix duplicate registration issue for mwc-* components

### DIFF
--- a/src/components/knx-sort-menu-item.ts
+++ b/src/components/knx-sort-menu-item.ts
@@ -23,7 +23,7 @@ import { mdiArrowDown, mdiArrowUp } from "@mdi/js";
 
 import "@ha/components/ha-icon-button";
 import "@ha/components/ha-svg-icon";
-import "@material/mwc-list/mwc-list-item";
+import "@ha/components/ha-list-item";
 
 import type { SortDirection, SortCriterion } from "../types/sorting";
 import { KnxSortMenu } from "./knx-sort-menu";
@@ -150,10 +150,7 @@ export class KnxSortMenuItem extends LitElement {
    */
   protected render(): TemplateResult {
     return html`
-      <mwc-list-item
-        class="sort-row ${this.active ? "active" : ""}"
-        @click=${this._handleItemClick}
-      >
+      <ha-list-item class="sort-row ${this.active ? "active" : ""}" @click=${this._handleItemClick}>
         <div class="container">
           <div class="sort-field-name" title=${this.displayName} aria-label=${this.displayName}>
             ${this.displayName}
@@ -175,7 +172,7 @@ export class KnxSortMenuItem extends LitElement {
             ></ha-icon-button>
           </div>
         </div>
-      </mwc-list-item>
+      </ha-list-item>
     `;
   }
 

--- a/src/components/knx-sort-menu.ts
+++ b/src/components/knx-sort-menu.ts
@@ -7,7 +7,7 @@
  * - Sort state management and synchronization
  * - Event-driven communication with parent components
  * - Accessibility support with proper ARIA implementation
- * - Material Design integration with mwc-menu
+ * - Material Design integration with ha-menu
  * - Flexible positioning and anchor support
  *
  * Architecture:
@@ -32,8 +32,7 @@ import { fireEvent } from "@ha/common/dom/fire_event";
 import "@ha/components/ha-icon-button";
 import "@ha/components/ha-svg-icon";
 import "@ha/components/ha-switch";
-import "@material/mwc-menu";
-import "@material/mwc-list/mwc-list-item";
+import "@ha/components/ha-menu";
 
 import "@ha/components/ha-icon-button-toggle";
 import type { SortDirection } from "../types/sorting";
@@ -85,15 +84,14 @@ export class KnxSortMenu extends LitElement {
   // ============================================================================
 
   /**
-   * Reference to the underlying mwc-menu element
-   * Used for programmatic menu control (open/close/positioning)
+   * Reference to the underlying ha-menu element
+   * Provides programmatic access to menu state and methods
    */
-  @query("mwc-menu") private _menu?: any;
-
-  /**
+  @query("ha-menu") private _menu?: any; /**
    * References to all slotted knx-sort-menu-item children
    * Automatically updated when child elements change
    */
+
   @queryAssignedElements({
     selector: "knx-sort-menu-item",
   })
@@ -145,7 +143,7 @@ export class KnxSortMenu extends LitElement {
    * Main render method that creates the dropdown menu structure
    *
    * Structure:
-   * - mwc-menu container with positioning and event handling
+   * - ha-menu container with positioning and event handling
    * - Slotted header with customizable title and toolbar
    * - Divider separator between header and items
    * - Slotted menu items with event delegation
@@ -155,7 +153,7 @@ export class KnxSortMenu extends LitElement {
   protected render() {
     return html`
       <div class="menu-container">
-        <mwc-menu
+        <ha-menu
           .corner=${"BOTTOM_START"}
           .fixed=${true}
           @opened=${this._handleMenuOpened}
@@ -177,7 +175,7 @@ export class KnxSortMenu extends LitElement {
 
           <!-- Menu items will be slotted here -->
           <slot @sort-option-selected=${this._handleSortOptionSelected}></slot>
-        </mwc-menu>
+        </ha-menu>
       </div>
     `;
   }

--- a/src/dialogs/knx-device-create-dialog.ts
+++ b/src/dialogs/knx-device-create-dialog.ts
@@ -21,13 +21,13 @@
  * 5. Parent receives new device entry or undefined on cancellation
  */
 
-import "@material/mwc-button/mwc-button";
 import { LitElement, html, css } from "lit";
 import { customElement, property, state } from "lit/decorators";
 
 import { navigate } from "@ha/common/navigate";
 import "@ha/components/ha-area-picker";
 import "@ha/components/ha-dialog";
+import "@ha/components/ha-button";
 import "@ha/components/ha-selector/ha-selector-text";
 
 import { fireEvent } from "@ha/common/dom/fire_event";
@@ -191,12 +191,12 @@ class DeviceCreateDialog extends LitElement {
         @value-changed=${this._valueChanged}
       >
       </ha-area-picker>
-      <mwc-button slot="secondaryAction" @click=${this.closeDialog}>
+      <ha-button slot="secondaryAction" @click=${this.closeDialog}>
         ${this.hass.localize("ui.common.cancel")}
-      </mwc-button>
-      <mwc-button slot="primaryAction" @click=${this._createDevice}>
+      </ha-button>
+      <ha-button slot="primaryAction" @click=${this._createDevice}>
         ${this.hass.localize("ui.common.add")}
-      </mwc-button>
+      </ha-button>
     </ha-dialog>`;
   }
 

--- a/src/dialogs/knx-telegram-info-dialog.ts
+++ b/src/dialogs/knx-telegram-info-dialog.ts
@@ -1,10 +1,10 @@
-import "@material/mwc-button/mwc-button";
 import { LitElement, nothing, html, css } from "lit";
 import { customElement, property } from "lit/decorators";
 import { fireEvent } from "@ha/common/dom/fire_event";
 import { haStyleDialog } from "@ha/resources/styles";
 import type { HomeAssistant } from "@ha/types";
 import "@ha/components/ha-svg-icon";
+import "@ha/components/ha-button";
 import "../components/knx-dialog-header";
 import { mdiArrowLeft, mdiArrowRight, mdiClose } from "@mdi/js";
 
@@ -177,20 +177,20 @@ class TelegramInfoDialog extends LitElement {
 
         <!-- Navigation buttons: previous / next -->
         <div slot="secondaryAction" style="margin: 0;">
-          <mwc-button
+          <ha-button
             class="nav-button"
             @click=${this._previousTelegram}
             .disabled=${this.disablePrevious}
           >
             <ha-svg-icon .path=${mdiArrowLeft}></ha-svg-icon>
             ${this.hass.localize("ui.common.previous")}
-          </mwc-button>
+          </ha-button>
         </div>
         <div slot="primaryAction">
-          <mwc-button class="nav-button" @click=${this._nextTelegram} .disabled=${this.disableNext}>
+          <ha-button class="nav-button" @click=${this._nextTelegram} .disabled=${this.disableNext}>
             ${this.hass.localize("ui.common.next")}
             <ha-svg-icon .path=${mdiArrowRight}></ha-svg-icon>
-          </mwc-button>
+          </ha-button>
         </div>
       </ha-dialog>
     `;

--- a/src/views/group_monitor.ts
+++ b/src/views/group_monitor.ts
@@ -6,7 +6,7 @@ import memoize from "memoize-one";
 import "@ha/layouts/hass-loading-screen";
 import "@ha/layouts/hass-tabs-subpage-data-table";
 import "@ha/components/ha-alert";
-import "@material/mwc-button";
+import "@ha/components/ha-button";
 import type { HASSDomEvent } from "@ha/common/dom/fire_event";
 import type {
   DataTableColumnContainer,
@@ -1411,11 +1411,11 @@ export class KNXGroupMonitor extends LitElement {
                 .title=${this.knx.localize("group_monitor_connection_error_title")}
               >
                 ${this._connectionError}
-                <mwc-button
+                <ha-button
                   slot="action"
                   @click=${this._retryConnection}
                   .label=${this.knx.localize("group_monitor_retry_connection")}
-                ></mwc-button>
+                ></ha-button>
               </ha-alert>
             `
           : nothing}
@@ -1428,11 +1428,11 @@ export class KNXGroupMonitor extends LitElement {
                 .title=${this.knx.localize("group_monitor_paused_title")}
               >
                 ${this.knx.localize("group_monitor_paused_message")}
-                <mwc-button
+                <ha-button
                   slot="action"
                   @click=${this._handlePauseToggle}
                   .label=${this.knx.localize("group_monitor_resume")}
-                ></mwc-button>
+                ></ha-button>
               </ha-alert>
             `
           : ""}


### PR DESCRIPTION
PR #241 introduced a problem when mwc-* components were directly imported into the KNX frontend. Since these components are already registered in `homeassistant-frontend`, importing them again caused conflicts.

This PR resolves the issue by switching to the native Home Assistant wrapper components, which ensures compatibility and prevents duplicate registrations.