### PR TITLE
Add missing translation key entities_title

### DIFF
--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -16,6 +16,7 @@
   "info_project_upload_description": "Wir extrahieren Details wie Namen, Gruppenadressen, Geräte, Gruppenobjekte, Topologie und Gebäudestruktur aus deiner Projektdatei. Home Assistant speichert jedoch aus Sicherheitsgründen weder die Projektdatei selbst, noch das optionale Passwort.",
   "info_issue_tracker": "Wenn du einen Fehler melden oder eine neue Funktion vorschlagen möchtest, erstelle ein Issue in unserem GitHub-Repository",
   "info_my_knx": "Wenn du mehr über das KNX System oder ETS erfahren möchtest, besuche",
+  "entities_title": "Entitäten",
   "entities_view_title": "Entitäten",
   "entities_create_title": "Entität erstellen",
   "entities_edit_title": "Entität bearbeiten",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -16,6 +16,7 @@
   "info_project_upload_description": "We extract details such as names, group addresses, devices, group objects, topology, and building structure from your project file. Home Assistant does not store the ETS project file itself nor its optional password for security reasons.",
   "info_issue_tracker": "If you'd like to report a bug or suggest a new feature, create an issue in our GitHub repository",
   "info_my_knx": "If you'd like to learn more about the KNX system or ETS, visit",
+  "entities_title": "Entities",
   "entities_view_title": "Entities",
   "entities_create_title": "Create entity",
   "entities_edit_title": "Edit entity",


### PR DESCRIPTION
When you open the Entity View, you may see this console error:
    
    [knx.localize] Translation problem with 'entities_title' for 'de'
    
This occurs because the router generates the `entities_title` key at runtime to set the browser’s page title. Since both `entities_view_title` and `entities_title` are dynamically generated translation keys, we must keep them both.