### PR TITLE
Fixes incorrect display of TimeOffset values greater than 1 hour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ yarn-error.log
 
 result.md
 
+# Test Coverage files
+test/coverage/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "develop": "./script/develop",
     "build": "./script/build",
+    "test": "vitest run --config test/vitest.config.ts",
+    "test:watch": "vitest --config test/vitest.config.ts",
+    "test:coverage": "vitest run --config test/vitest.config.ts --coverage",
     "lint:eslint": "eslint --flag unstable_config_lookup_from_file \"./src/**/*.{js,ts,html}\" --ignore-pattern .gitignore --max-warnings=0",
     "format:eslint": "eslint --flag unstable_config_lookup_from_file \"./src/**/*.{js,ts,html}\" --fix --ignore-pattern .gitignore",
     "lint:prettier": "prettier \"./src/**/*.{js,ts,json,css,md}\" --check",

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -127,14 +127,19 @@ export const formatIsoTimestampWithMicroseconds = (timestampIso: string): string
 };
 
 /**
- * Format a Date object representing a time offset to MM:SS.MMM format.
+ * Formats a time duration into a human-readable string format.
+ * Returns MM:SS.mmm for durations under 1 hour, or HH:MM:SS.mmm for longer durations.
  *
- * @param offset - The Date object containing the time difference
- * @returns Formatted string in MM:SS.MMM format
+ * @param offset - Date object representing the duration (milliseconds since epoch)
+ * @returns Formatted duration string (e.g., "15:30.250" or "02:15:30.250")
  */
 export const formatOffset = (offset: Date): string => {
-  const minutes = offset.getUTCMinutes().toString().padStart(2, "0");
-  const seconds = offset.getUTCSeconds().toString().padStart(2, "0");
-  const milliseconds = offset.getUTCMilliseconds().toString().padStart(3, "0");
-  return `${minutes}:${seconds}.${milliseconds}`;
+  const ms = offset.getTime();
+  const hours = Math.floor(ms / 3600000); // 60 * 60 * 1000
+  const remainder = ms % 3600000;
+
+  // Extract "MM:SS.mmm" from ISO string
+  const timeStr = new Date(remainder).toISOString().slice(14, 23);
+
+  return hours > 0 ? `${hours.toString().padStart(2, "0")}:${timeStr}` : timeStr;
 };

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,6 @@
+import { beforeAll } from "vitest";
+
+beforeAll(() => {
+  global.window = {} as any;
+  global.navigator = {} as any;
+});

--- a/test/utils/format.test.ts
+++ b/test/utils/format.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { formatOffset } from "../../src/utils/format";
+
+describe("formatOffset", () => {
+  it("should format minutes and seconds without hours", () => {
+    const offset = new Date(2 * 60 * 1000 + 30 * 1000 + 500);
+    expect(formatOffset(offset)).toBe("02:30.500");
+  });
+
+  it("should format with hours when present", () => {
+    const offset = new Date(2 * 60 * 60 * 1000 + 15 * 60 * 1000 + 30 * 1000 + 250);
+    expect(formatOffset(offset)).toBe("02:15:30.250");
+  });
+
+  it("should handle large hour values (multi-day offsets)", () => {
+    const offset = new Date(122 * 60 * 60 * 1000 + 15 * 60 * 1000 + 30 * 1000 + 250);
+    expect(formatOffset(offset)).toBe("122:15:30.250");
+  });
+
+  it("should handle zero offset", () => {
+    const offset = new Date(0);
+    expect(formatOffset(offset)).toBe("00:00.000");
+  });
+
+  it("should pad single digit values correctly", () => {
+    const offset = new Date(5 * 60 * 60 * 1000 + 3 * 60 * 1000 + 7 * 1000 + 9);
+    expect(formatOffset(offset)).toBe("05:03:07.009");
+  });
+
+  it("should handle edge cases", () => {
+    // Milliseconds only
+    expect(formatOffset(new Date(123))).toBe("00:00.123");
+    
+    // Exactly 1 hour
+    expect(formatOffset(new Date(60 * 60 * 1000))).toBe("01:00:00.000");
+    
+    // Max values before next unit
+    expect(formatOffset(new Date(59 * 60 * 1000 + 59 * 1000 + 999))).toBe("59:59.999");
+  });
+});

--- a/test/vitest.config.ts
+++ b/test/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "jsdom", // to run in browser-like environment
+    env: {
+      TZ: "Etc/UTC",
+      IS_TEST: "true",
+    },
+    exclude: ["homeassistant-frontend/**/*", "**/node_modules/**", "build/**/*"],
+    setupFiles: ["./test/setup.ts"],
+    coverage: {
+      include: ["src/**/*.ts"],
+      reporter: ["text", "html"],
+      provider: "v8",
+      reportsDirectory: "test/coverage",
+    },
+  },
+});


### PR DESCRIPTION
Currently, the TimeOffset in the GroupMonitor is not displayed correctly when the duration exceeds one hour. The hour part is silently omitted, and only minutes, seconds, and milliseconds are shown.

This PR fixes the formatting logic to include the hour part if present.

Additionally, I enabled the test framework and added a first unit test to cover this use case.