### PR TITLE
Add override_branch and override_commit to Codecov upload step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./test/coverage
           fail_ci_if_error: true
+          override_branch: ${{ github.ref_name }}
+          override_commit: ${{ github.sha }}
 
   build:
     name: Build


### PR DESCRIPTION
I noticed that the main branch in Codecov isn't updating correctly.
I’ve added the following lines, which seemed to fix the issue in a test run on my fork:

    override_branch: ${{ github.ref_name }}
    override_commit: ${{ github.sha }}

Hopefully, this resolves it here as well.