### PR TITLE
Show only selectable sorting options in filters

### DIFF
--- a/src/components/knx-sort-menu-item.ts
+++ b/src/components/knx-sort-menu-item.ts
@@ -318,7 +318,7 @@ export class KnxSortMenuItem extends LitElement {
     .sort-row.disabled {
       opacity: 0.6;
       cursor: not-allowed;
-      pointer-events: auto;
+      pointer-events: none;
     }
 
     .sort-row.disabled.active {

--- a/src/components/knx-sort-menu-item.ts
+++ b/src/components/knx-sort-menu-item.ts
@@ -1,17 +1,7 @@
 /**
  * KNX Sort Menu Item Component
  *
- * Individual sort option component for the KNX sort menu system that provides
- * interactive sort direction selection (ascending/descending), visual feedback
- * for active sort state, customizable icons and text labels, accessibility
- * support with ARIA attributes, hover effects for better user experience,
- * and integration with the parent sort menu component.
- *
- * Includes default direction support for initial sort selection, custom icon
- * support for ascending/descending buttons, localized text labels with
- * fallback support, click handling for both item and individual direction
- * buttons, event propagation control for nested interactions, and responsive
- * button visibility (hidden until hover or active).
+ * Individual sort option for knx-sort-menu.
  */
 
 import { css, html, LitElement, nothing } from "lit";
@@ -117,6 +107,12 @@ export class KnxSortMenuItem extends LitElement {
   @property({ type: Boolean, attribute: "is-mobile-device" })
   public isMobileDevice = false;
 
+  /**
+   * Whether this sort menu item is disabled
+   * When disabled, the item and buttons cannot be clicked but the active state is still visible
+   */
+  @property({ type: Boolean }) public disabled = false;
+
   // ============================================================================
   // Computed Properties
   // ============================================================================
@@ -154,12 +150,16 @@ export class KnxSortMenuItem extends LitElement {
    * - Direction buttons (ascending/descending) with conditional visibility
    * - On mobile devices: only show active button that works as toggle
    * - On desktop: show both buttons on hover, always show active button
+   * - When disabled: prevent clicks but maintain visual state
    *
    * @returns Template result for the complete menu item
    */
   protected render(): TemplateResult {
     return html`
-      <ha-list-item class="sort-row ${this.active ? "active" : ""}" @click=${this._handleItemClick}>
+      <ha-list-item
+        class="sort-row ${this.active ? "active" : ""} ${this.disabled ? "disabled" : ""}"
+        @click=${this.disabled ? nothing : this._handleItemClick}
+      >
         <div class="container">
           <div class="sort-field-name" title=${this.displayName} aria-label=${this.displayName}>
             ${this.displayName}
@@ -190,7 +190,8 @@ export class KnxSortMenuItem extends LitElement {
         .path=${isDescending ? this.descendingIcon : this.ascendingIcon}
         .label=${isDescending ? this._descendingText : this._ascendingText}
         .title=${isDescending ? this._descendingText : this._ascendingText}
-        @click=${this._handleMobileButtonClick}
+        .disabled=${this.disabled}
+        @click=${this.disabled ? nothing : this._handleMobileButtonClick}
       ></ha-icon-button>
     `;
   }
@@ -208,14 +209,16 @@ export class KnxSortMenuItem extends LitElement {
         .path=${this.descendingIcon}
         .label=${this._descendingText}
         .title=${this._descendingText}
-        @click=${this._handleDescendingClick}
+        .disabled=${this.disabled}
+        @click=${this.disabled ? nothing : this._handleDescendingClick}
       ></ha-icon-button>
       <ha-icon-button
         class=${this.active && this.direction === KnxSortMenu.ASC ? "active" : ""}
         .path=${this.ascendingIcon}
         .label=${this._ascendingText}
         .title=${this._ascendingText}
-        @click=${this._handleAscendingClick}
+        .disabled=${this.disabled}
+        @click=${this.disabled ? nothing : this._handleAscendingClick}
       ></ha-icon-button>
     `;
   }
@@ -312,6 +315,19 @@ export class KnxSortMenuItem extends LitElement {
       font-weight: 500;
     }
 
+    .sort-row.disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      pointer-events: auto;
+    }
+
+    .sort-row.disabled.active {
+      --mdc-theme-text-primary-on-background: var(--primary-color);
+      background-color: var(--mdc-theme-surface-variant, rgba(var(--rgb-primary-color), 0.06));
+      font-weight: 500;
+      opacity: 0.6;
+    }
+
     .container {
       display: flex;
       justify-content: space-between;
@@ -349,9 +365,25 @@ export class KnxSortMenuItem extends LitElement {
       display: flex;
     }
 
+    /* Don't show hover buttons when disabled */
+    .sort-row.disabled:hover .sort-buttons ha-icon-button:not(.active) {
+      display: none;
+    }
+
     .sort-buttons ha-icon-button.active {
       display: flex;
       color: var(--primary-color);
+    }
+
+    /* Disabled buttons styling */
+    .sort-buttons ha-icon-button[disabled] {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
+    .sort-buttons ha-icon-button.active[disabled] {
+      --icon-primary-color: var(--primary-color);
+      opacity: 0.6;
     }
 
     /* Mobile device specific styles */

--- a/src/features/group-monitor/views/group-monitor-view.ts
+++ b/src/features/group-monitor/views/group-monitor-view.ts
@@ -25,7 +25,7 @@ import "../../../components/data-table/cell/knx-table-cell-filterable";
 import "../dialogs/telegram-info-dialog";
 import "../../../components/data-table/filter/knx-list-filter";
 
-import { customElement, property } from "lit/decorators";
+import { customElement, property, query } from "lit/decorators";
 import { mdiDeleteSweep, mdiFastForward, mdiPause, mdiRefresh } from "@mdi/js";
 import { formatTimeWithMilliseconds, formatTimeDelta } from "../../../utils/format";
 import type { TelegramRow, TelegramRowKeys } from "../types/telegram-row";
@@ -38,6 +38,7 @@ import type {
   SelectionChangedEvent as ListFilterSelectionChangedEvent,
   ExpandedChangedEvent as ListFilterExpandedChangedEvent,
   Config as ListFilterConfig,
+  KnxListFilter,
 } from "../../../components/data-table/filter/knx-list-filter";
 
 /**
@@ -128,6 +129,12 @@ export class KNXGroupMonitor extends LitElement {
 
   /** GroupMonitor controller instance */
   private controller = new GroupMonitorController(this);
+
+  /** Reference to source filter component */
+  @query('knx-list-filter[data-filter="source"]') private sourceFilter?: KnxListFilter;
+
+  /** Reference to destination filter component */
+  @query('knx-list-filter[data-filter="destination"]') private destinationFilter?: KnxListFilter;
 
   /**
    * Detects if the current device is a mobile touch device
@@ -229,7 +236,8 @@ export class KNXGroupMonitor extends LitElement {
         filteredCount: {
           fieldName: this.knx.localize("telegram_filter_sort_by_filtered_count"),
           filterable: false,
-          sortable: true,
+          sortable: this.hasActiveFilters || this.sourceFilter?.sortCriterion === "filteredCount",
+          sortDisabled: !this.hasActiveFilters,
           sortAscendingText: this.knx.localize("telegram_filter_sort_ascending"),
           sortDescendingText: this.knx.localize("telegram_filter_sort_descending"),
           sortDefaultDirection: "desc",
@@ -288,7 +296,9 @@ export class KNXGroupMonitor extends LitElement {
         filteredCount: {
           fieldName: this.knx.localize("telegram_filter_sort_by_filtered_count"),
           filterable: false,
-          sortable: true,
+          sortable:
+            this.hasActiveFilters || this.destinationFilter?.sortCriterion === "filteredCount",
+          sortDisabled: !this.hasActiveFilters,
           sortAscendingText: this.knx.localize("telegram_filter_sort_ascending"),
           sortDescendingText: this.knx.localize("telegram_filter_sort_descending"),
           sortDefaultDirection: "desc",


### PR DESCRIPTION
This PR ensures that only sorting options relevant to the current context are displayed in the filters. The Sort by Filter Count option is now only shown when filter options are currently selected or when this sorting option is already active.