### PR TITLE
Improve Group Monitor layout spacing and navbar behavior

### DIFF
--- a/src/components/data-table/filter/knx-list-filter.ts
+++ b/src/components/data-table/filter/knx-list-filter.ts
@@ -1339,7 +1339,6 @@ export class KnxListFilter<T = any> extends LitElement {
           justify-content: space-between;
           align-items: center;
           width: 100%;
-          margin-bottom: 4px;
         }
 
         .option-label {

--- a/src/features/group-monitor/views/group-monitor-view.ts
+++ b/src/features/group-monitor/views/group-monitor-view.ts
@@ -14,7 +14,6 @@ import type {
   SortingChangedEvent,
 } from "@ha/components/data-table/ha-data-table";
 import "@ha/components/ha-icon-button";
-import { haStyle } from "@ha/resources/styles";
 import type { HomeAssistant, Route } from "@ha/types";
 import type { PageNavigation } from "@ha/layouts/hass-tabs-subpage";
 import { isMobileClient } from "@ha/util/is_mobile";
@@ -74,7 +73,6 @@ export class KNXGroupMonitor extends LitElement {
   // Static definitions
   static get styles(): CSSResultGroup {
     return [
-      haStyle,
       css`
         :host {
           --table-row-alternative-background-color: var(--primary-background-color);


### PR DESCRIPTION
This PR makes a small layout optimization and a bug fix:
- Reduced the spacing between the name and description in the list filters for a cleaner look.
<img width="300"  alt="Bildschirmfoto 2025-08-07 um 00 24 23" src="https://github.com/user-attachments/assets/0a250cad-29e7-42eb-8afa-47549865a202" /><img width="300"  alt="Bildschirmfoto 2025-08-07 um 00 25 40" src="https://github.com/user-attachments/assets/bf459cfa-043f-40f8-9cd5-f9597a7d46a9" />
- Fixed a visual glitch occurred when switching between the Group Monitor and other menu entries

https://github.com/user-attachments/assets/1867a539-a2ad-4eb5-9f26-8102927e906d

