### PR TITLE
Add banner in group monitor when no ETS project is loaded + various bugfixes

### DIFF
--- a/src/components/data-table/filter/knx-list-filter.ts
+++ b/src/components/data-table/filter/knx-list-filter.ts
@@ -754,6 +754,12 @@ export class KnxListFilter<T = any> extends LitElement {
   ): void {
     this.sortCriterion = ev.detail.criterion;
     this.sortDirection = ev.detail.direction;
+
+    // Notify parent so it can react immediately (e.g., recompute memoized configs)
+    fireEvent(this, "sort-changed", {
+      criterion: this.sortCriterion,
+      direction: this.sortDirection,
+    });
   }
 
   /**

--- a/src/components/data-table/filter/knx-list-filter.ts
+++ b/src/components/data-table/filter/knx-list-filter.ts
@@ -1324,6 +1324,7 @@ export class KnxListFilter<T = any> extends LitElement {
           width: 100%;
           min-width: 0;
           height: 100%;
+          line-height: normal;
         }
 
         .option-primary {
@@ -1331,6 +1332,7 @@ export class KnxListFilter<T = any> extends LitElement {
           justify-content: space-between;
           align-items: center;
           width: 100%;
+          margin-bottom: 3px;
         }
 
         .option-label {

--- a/src/components/knx-sort-menu-item.ts
+++ b/src/components/knx-sort-menu-item.ts
@@ -317,7 +317,6 @@ export class KnxSortMenuItem extends LitElement {
 
     .sort-row.disabled {
       opacity: 0.6;
-      cursor: not-allowed;
       pointer-events: none;
     }
 

--- a/src/features/group-monitor/controller/group-monitor-controller.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller.ts
@@ -82,7 +82,8 @@ export class GroupMonitorController implements ReactiveController {
 
   private _isPaused = false;
 
-  private _isProjectLoaded = false;
+  // undefined until initial info is fetched; then true/false
+  private _isProjectLoaded: boolean | undefined = undefined;
 
   private _connectionError: string | null = null;
 
@@ -194,7 +195,7 @@ export class GroupMonitorController implements ReactiveController {
     return this._isPaused;
   }
 
-  public get isProjectLoaded(): boolean {
+  public get isProjectLoaded(): boolean | undefined {
     return this._isProjectLoaded;
   }
 
@@ -309,7 +310,7 @@ export class GroupMonitorController implements ReactiveController {
           // For timestamp sorting, we want to show the time difference since the chronologically previous telegram
           let previousTelegram: TelegramRow | null = null;
 
-          if (sortDirection === "desc") {
+          if (sortDirection === "desc" && sortColumn) {
             // In descending order (newest first): [10:30, 10:25, 10:20]
             // The chronologically previous telegram is at i+1 (older timestamp)
             previousTelegram = i < filteredTelegrams.length - 1 ? filteredTelegrams[i + 1] : null;

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -40,6 +40,8 @@
   "group_monitor_paused_title": "Monitoring pausiert",
   "group_monitor_paused_message": "Die Telegramm-Überwachung ist pausiert. Neue Telegramme werden erst nach dem Fortsetzen der Überwachung angezeigt.",
   "group_monitor_telegram": "KNX Telegramm",
+  "group_monitor_project_not_loaded_title": "Kein ETS Projekt geladen",
+  "group_monitor_project_not_loaded_message": "Für zusätzliche Informationen wie Namen und Werte lade bitte dein ETS Projekt im Info-Tab hoch.",
   "project_title": "Projekt",
   "project_view_upload": "Keine Projektdaten gefunden. Wechsle zum Info Tab und lade eine Projektdatei hoch.",
   "project_view_version_l1": "Die Version von `XKNXProject` welche für die Verarbeitung des ETS Projektes verwendet wurde, war:",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -40,6 +40,8 @@
   "group_monitor_paused_title": "Monitoring Paused",
   "group_monitor_paused_message": "Telegram monitoring is paused. New telegrams will not be displayed until you resume monitoring.",
   "group_monitor_telegram": "KNX Telegram",
+  "group_monitor_project_not_loaded_title": "ETS project not loaded",
+  "group_monitor_project_not_loaded_message": "For richer context like names and values, upload your ETS project on the Info tab.",
   "project_title": "Project",
   "project_view_upload": "To use the project viewr please upload a KNX project on Info tab first!",
   "project_view_version_l1": "The `XKNXProject` version used for parsing the ETS project was:",

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -43,7 +43,7 @@
   "group_monitor_project_not_loaded_title": "ETS project not loaded",
   "group_monitor_project_not_loaded_message": "For richer context like names and values, upload your ETS project on the Info tab.",
   "project_title": "Project",
-  "project_view_upload": "To use the project viewr please upload a KNX project on Info tab first!",
+  "project_view_upload": "To use the project viewer please upload a KNX project on Info tab first!",
   "project_view_version_l1": "The `XKNXProject` version used for parsing the ETS project was:",
   "project_view_version_l2": "minimum version required",
   "project_view_version_l3": "Please resubmit your ETS project file.",


### PR DESCRIPTION
**New Feature:**

- When opening the group monitor without an ETS project loaded, a banner is now displayed, informing the user that more details are available after uploading the ETS file.

<img width="1111" height="319" alt="image" src="https://github.com/user-attachments/assets/3eb0ea92-b06e-404f-9097-5ac594c8fa94" />

**Bugfixes:**

- Fixed offset formatting issue when no field was sorted (natural sorting).
- Fixed display bug in the sort menu where sorting entries were hidden with delay, even though they were already inactive.
- Cached FilterPanel config to reduce redundant renders.
- Minor CSS improvements.