### PR TITLE
Load project info and project data directly to knx object

### DIFF
--- a/src/components/knx-group-address-selector.ts
+++ b/src/components/knx-group-address-selector.ts
@@ -77,8 +77,8 @@ export class GroupAddressSelector extends LitElement {
     this.hass.localize(`component.knx.config_panel.entities.create._.knx.knx_group_address.${key}`);
 
   getValidGroupAddresses(validDPTs: DPT[]): GroupAddress[] {
-    return this.knx.project?.project_loaded
-      ? Object.values(this.knx.project.knxproject.group_addresses).filter((groupAddress) =>
+    return this.knx.projectData
+      ? Object.values(this.knx.projectData.group_addresses).filter((groupAddress) =>
           groupAddress.dpt ? isValidDPT(groupAddress.dpt, validDPTs) : false,
         )
       : [];
@@ -115,7 +115,7 @@ export class GroupAddressSelector extends LitElement {
       const selectedDPT = this.getDptOptionByValue(this._selectedDPTValue)?.dpt;
       this.setFilteredGroupAddresses(selectedDPT);
 
-      if (selectedDPT && this.knx.project?.project_loaded) {
+      if (selectedDPT && this.knx.projectData) {
         const allDpts = [
           this.config.write,
           this.config.state,
@@ -124,7 +124,7 @@ export class GroupAddressSelector extends LitElement {
         this.dptSelectorDisabled =
           allDpts.length > 0 &&
           allDpts.every((ga) => {
-            const _dpt = this.knx.project?.knxproject.group_addresses[ga!]?.dpt;
+            const _dpt = this.knx.projectData!.group_addresses[ga!]?.dpt;
             return _dpt ? isValidDPT(_dpt, [selectedDPT]) : false;
           });
       } else {
@@ -299,7 +299,7 @@ export class GroupAddressSelector extends LitElement {
     }
 
     // below only applies to loaded projects as it inferes DPT from selected group address
-    if (!this.knx.project?.project_loaded) return;
+    if (!this.knx.projectData) return;
 
     const newGa = this._getAddedGroupAddress(targetKey, newConfig);
     if (!newGa || this._selectedDPTValue !== undefined) return;

--- a/src/knx-router.ts
+++ b/src/knx-router.ts
@@ -112,7 +112,7 @@ export class KnxRouter extends HassRouterPage {
     el.knx = this.knx;
     el.route = this.routeTail;
     el.narrow = this.narrow;
-    el.tabs = knxMainTabs(!!this.knx.info.project);
+    el.tabs = knxMainTabs(!!this.knx.projectInfo);
   }
 }
 

--- a/src/knx.ts
+++ b/src/knx.ts
@@ -25,9 +25,10 @@ export class KnxElement extends ProvideHassLitMixin(LitElement) {
         config_entry: knxConfigEntries[0], // single instance allowed for knx config
         localize: (string, replace) => localize(this.hass, string, replace),
         log: new KNXLogger(),
-        info: knxBase.info,
+        connectionInfo: knxBase.connection_info,
+        projectInfo: knxBase.project_info, // can  be used to check if project is available
         supportedPlatforms: knxBase.supported_platforms,
-        project: null,
+        projectData: null,
         loadProject: () => this._loadProjectPromise(),
         schema: {},
         loadSchema: (platform: string) => this._loadSchema(platform),
@@ -39,10 +40,10 @@ export class KnxElement extends ProvideHassLitMixin(LitElement) {
 
   private _loadProjectPromise(): Promise<void> {
     // load project only when needed since it can be quite big
-    // check this.knx.project if it is available in using component
+    // check if this.knx.projectData is available before using in component
     return getKnxProject(this.hass)
-      .then((knxProjectResp) => {
-        this.knx.project = knxProjectResp;
+      .then((knxProject) => {
+        this.knx.projectData = knxProject;
       })
       .catch((err) => {
         this.knx.log.error("getKnxProject", err);

--- a/src/services/websocket.service.ts
+++ b/src/services/websocket.service.ts
@@ -10,8 +10,8 @@ import type {
 import type { SelectorSchema } from "../types/schema";
 import type {
   TelegramDict,
+  KNXProject,
   GroupMonitorInfoData,
-  KNXProjectResponse,
   KNXBaseData,
 } from "../types/websocket";
 
@@ -54,7 +54,7 @@ export const subscribeKnxTelegrams = (
     type: "knx/subscribe_telegrams",
   });
 
-export const getKnxProject = (hass: HomeAssistant): Promise<KNXProjectResponse> =>
+export const getKnxProject = (hass: HomeAssistant): Promise<KNXProject | null> =>
   hass.callWS({
     type: "knx/get_knx_project",
   });

--- a/src/types/knx.ts
+++ b/src/types/knx.ts
@@ -1,16 +1,17 @@
 import type { ConfigEntry } from "@ha/data/config_entries";
 import type { SupportedPlatform } from "./entity_data";
 import type { SelectorSchema } from "./schema";
-import type { KNXInfoData, KNXProjectResponse } from "./websocket";
+import type { KNXInfoData, KNXProjectInfo, KNXProject } from "./websocket";
 
 export interface KNX {
   language: string;
   config_entry: ConfigEntry;
   localize(string: string, replace?: Record<string, any>): string;
   log: any;
-  info: KNXInfoData;
+  connectionInfo: KNXInfoData;
+  projectInfo: KNXProjectInfo | null;
   supportedPlatforms: SupportedPlatform[];
-  project: KNXProjectResponse | null;
+  projectData: KNXProject | null;
   loadProject(): Promise<void>;
   schema: Partial<Record<SupportedPlatform, SelectorSchema[]>>;
   loadSchema(platform: string): Promise<void>;

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -1,16 +1,15 @@
 import type { SupportedPlatform } from "./entity_data";
 
 export interface KNXBaseData {
-  info: KNXInfoData; // TODO: rename to connection?
+  connection_info: KNXInfoData;
+  project_info: KNXProjectInfo | null;
   supported_platforms: SupportedPlatform[];
-  // TODO: move `project` key from KNXInfoData to here - remove `project_loaded` from KNXProjectResponse and use directly (also GroupMonitorInfoData)
 }
 
 export interface KNXInfoData {
   version: string;
   connected: boolean;
   current_address: string;
-  project: KNXProjectInfo | null;
 }
 
 export interface KNXProjectInfo {
@@ -40,11 +39,6 @@ export interface TelegramDict {
   timestamp: string; // ISO 8601 eg. "2023-06-21T22:28:45.446257+02:00" from `dt_util.as_local(dt_util.utcnow())`
   unit: string | null;
   value: string | number | boolean | null;
-}
-
-export interface KNXProjectResponse {
-  project_loaded: boolean;
-  knxproject: KNXProject;
 }
 
 export interface KNXProject {

--- a/src/views/info.ts
+++ b/src/views/info.ts
@@ -53,7 +53,7 @@ export class KNXInfo extends LitElement {
       >
         <div class="columns">
           ${this._renderInfoCard()}
-          ${this.knx.info.project ? this._renderProjectDataCard(this.knx.info.project) : nothing}
+          ${this.knx.projectInfo ? this._renderProjectDataCard(this.knx.projectInfo) : nothing}
           ${this._renderProjectUploadCard()}
         </div>
       </hass-tabs-subpage>
@@ -67,7 +67,7 @@ export class KNXInfo extends LitElement {
 
         <div class="knx-content-row">
           <div>XKNX Version</div>
-          <div>${this.knx.info.version}</div>
+          <div>${this.knx.connectionInfo.version}</div>
         </div>
 
         <div class="knx-content-row">
@@ -78,13 +78,15 @@ export class KNXInfo extends LitElement {
         <div class="knx-content-row">
           <div>${this.knx.localize("info_connected_to_bus")}</div>
           <div>
-            ${this.hass.localize(this.knx.info.connected ? "ui.common.yes" : "ui.common.no")}
+            ${this.hass.localize(
+              this.knx.connectionInfo.connected ? "ui.common.yes" : "ui.common.no",
+            )}
           </div>
         </div>
 
         <div class="knx-content-row">
           <div>${this.knx.localize("info_individual_address")}</div>
-          <div>${this.knx.info.current_address}</div>
+          <div>${this.knx.connectionInfo.current_address}</div>
         </div>
 
         <div class="knx-bug-report">
@@ -127,7 +129,7 @@ export class KNXInfo extends LitElement {
               <ha-button
                 class="knx-warning push-right"
                 @click=${this._removeProject}
-                .disabled=${this._uploading || !this.knx.info.project}
+                .disabled=${this._uploading || !this.knx.projectInfo}
                 >
                 ${this.knx.localize("info_project_delete")}
               </ha-button>


### PR DESCRIPTION
So we can just check `this.knx.projectInfo?` for a project being available 
and `this.knx.projectData?` for the project being loaded.

Also use a lit Task to load the project if not already done. In future this can be expanded by using projectInfo (timestamp and parser version) as fingerprint to load from a localstorage cache or something like that.