### PR TITLE
Allow ha-selector translation

### DIFF
--- a/src/components/knx-selector-row.ts
+++ b/src/components/knx-selector-row.ts
@@ -65,6 +65,7 @@ export class KnxSelectorRow extends LitElement {
           .selector=${this.selector.selector}
           .disabled=${this._disabled}
           .value=${this._haSelectorValue}
+          .localizeValue=${this.hass.localize}
           @value-changed=${this._valueChange}
         ></ha-selector>`;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,7 @@ class KnxFrontend extends KnxElement {
     }
     await this.hass.loadBackendTranslation("config_panel", "knx", false);
     await this.hass.loadBackendTranslation("title", this.knx.supportedPlatforms, false);
+    await this.hass.loadBackendTranslation("selector", this.knx.supportedPlatforms, false);
     await this.hass.loadFragmentTranslation("config");
     this.addEventListener("knx-location-changed", (e) => this._setRoute(e as LocationChangedEvent));
 


### PR DESCRIPTION
with full translation path (eg. `translation_key="component.climate.selector.hvac_mode"`).
Platform selector translation keys will be preloaded and can be used (example above). 

For select-selectors, the referenced keys do need to have an `options` key holding the individual selectors translations.