### PR TITLE
GA selector: show more prominent label and description

### DIFF
--- a/src/components/knx-group-address-selector.ts
+++ b/src/components/knx-group-address-selector.ts
@@ -158,6 +158,8 @@ export class GroupAddressSelector extends LitElement {
     const gaDescription = this.localizeFunction(this.key + ".description");
 
     return html`
+      <p class="title">${this.label}</p>
+      ${gaDescription ? html`<p class="description">${gaDescription}</p>` : nothing}
       ${generalValidationError
         ? html`<p class="error">
             <ha-svg-icon .path=${mdiAlertCircleOutline}></ha-svg-icon>
@@ -242,7 +244,6 @@ export class GroupAddressSelector extends LitElement {
           @drop=${this._dropHandler}
         ></ha-selector-select>
       </div>
-      ${gaDescription ? html`<p class="description">${gaDescription}</p>` : nothing}
       ${this.options.validDPTs
         ? html`<p class="valid-dpts">
             ${this._baseTranslation("valid_dpts")}:
@@ -427,7 +428,16 @@ export class GroupAddressSelector extends LitElement {
       height: auto;
     }
 
-    .description,
+    .title {
+      margin-bottom: 12px;
+    }
+    .description {
+      margin-top: -10px;
+      margin-bottom: 12px;
+      color: var(--secondary-text-color);
+      font-size: var(--ha-font-size-s);
+    }
+
     .valid-dpts {
       margin-top: -8px;
       margin-bottom: 12px;


### PR DESCRIPTION
Instead of only using label and having the description below input boxes (above "Valid DPTs").
So it looks more like HAs standard selectors.

<img width="775" height="359" alt="Bildschirmfoto 2025-10-17 um 22 18 05" src="https://github.com/user-attachments/assets/8e8b0f2f-95da-4f22-a687-238d0bfcd079" />
