### PR TITLE
Fix sync state dropdown rendering and add option labels

### DIFF
--- a/src/components/knx-sync-state-selector-row.ts
+++ b/src/components/knx-sync-state-selector-row.ts
@@ -27,7 +27,7 @@ export class KnxSyncStateSelectorRow extends LitElement {
 
   private _minutes = 60;
 
-  private get _options(): ("true" | "false" | "init" | "expire" | "every")[] {
+  private get _options(): readonly string[] {
     return this.allowFalse
       ? ["true", "init", "expire", "every", "false"]
       : ["true", "init", "expire", "every"];
@@ -44,7 +44,16 @@ export class KnxSyncStateSelectorRow extends LitElement {
       return;
     }
     const [strategy, minutes] = this.value.split(" ");
-    this._strategy = strategy as "true" | "false" | "init" | "expire" | "every";
+
+    // Validate strategy value before assignment
+    const validStrategies = ["true", "false", "init", "expire", "every"] as const;
+    if (validStrategies.includes(strategy as any)) {
+      this._strategy = strategy as typeof this._strategy;
+    } else {
+      // Fallback to default for invalid values
+      this._strategy = "true";
+    }
+
     if (+minutes) {
       this._minutes = +minutes;
     }
@@ -62,7 +71,7 @@ export class KnxSyncStateSelectorRow extends LitElement {
             multiple: false,
             custom_value: false,
             mode: "dropdown" as const,
-            options: this._options as readonly string[],
+            options: this._options,
           },
         }}
         .key=${"strategy"}


### PR DESCRIPTION
Fixes TypeScript type errors in `knx-sync-state-selector-row` component.

**The issue:**
`ha-selector-select` expects string values, but we were mixing booleans (`true`/`false`) with strings (`"init"`, `"expire"`, `"every"`), causing TypeScript errors.

**The fix:**
- Convert booleans to strings internally (`"true"`/`"false"`)
- Map back to booleans when sending to backend
- Backend API stays unchanged (still receives `true`/`false` as booleans)

Related to #157

before:
<img width="733" height="250" alt="image" src="https://github.com/user-attachments/assets/2e11048f-46ab-4566-8b80-40b16f16aa1b" />
after:
<img width="739" height="260" alt="image" src="https://github.com/user-attachments/assets/8a63a146-b22b-49e3-99c8-1a18d261f0a7" />
