### PR TITLE
Fix/mobile hamburger menu

### DIFF
--- a/src/features/group-monitor/views/group-monitor-view.ts
+++ b/src/features/group-monitor/views/group-monitor-view.ts
@@ -883,6 +883,7 @@ export class KNXGroupMonitor extends LitElement {
         .narrow=${this.narrow!}
         .route=${this.route!}
         .tabs=${this.tabs}
+        main-page
         .columns=${this._columns(
           this.narrow,
           this.controller.isProjectLoaded === true,

--- a/src/views/entities_view.ts
+++ b/src/views/entities_view.ts
@@ -275,6 +275,7 @@ export class KNXEntitiesView extends LitElement {
         .route=${this.route!}
         .tabs=${this.tabs}
         .localizeFunc=${this.knx.localize}
+        main-page
         .columns=${this._columns(this.hass.language)}
         .data=${this.knx_entities}
         .hasFab=${true}

--- a/src/views/info.ts
+++ b/src/views/info.ts
@@ -50,6 +50,7 @@ export class KNXInfo extends LitElement {
         .route=${this.route!}
         .tabs=${this.tabs}
         .localizeFunc=${this.knx.localize}
+        main-page
       >
         <div class="columns">
           ${this._renderInfoCard()}

--- a/src/views/project_view.ts
+++ b/src/views/project_view.ts
@@ -231,6 +231,7 @@ export class KNXProjectView extends LitElement {
       .route=${this.route!}
       .tabs=${this.tabs}
       .localizeFunc=${this.knx.localize}
+      main-page
     >
       ${this._projectLoadTask.render({
         initial: () => html`


### PR DESCRIPTION
## What does this implement/fix?

Adds the `main-page` attribute to all main views (Info, Group Monitor, Project, Entities) of the KNX integration to display the hamburger menu button instead of a back arrow on narrow/mobile screens.

## Why was this needed?

Currently, the KNX integration shows only a back arrow on mobile devices, which is inconsistent with other Home Assistant panels and prevents users from accessing the sidebar menu on mobile.

## Changes

- Added `main-page` attribute to `hass-tabs-subpage` in Info View
- Added `main-page` attribute to `hass-tabs-subpage-data-table` in Group Monitor View  
- Added `main-page` attribute to `hass-tabs-subpage` in Project View
- Added `main-page` attribute to `hass-tabs-subpage-data-table` in Entities View

This makes the navigation behavior consistent with other Home Assistant panels like Profile, Settings, etc.

## Screenshots

<img width="276" height="600" alt="localhost_8123_knx_info(iPhone 14 Pro Max)before" src="https://github.com/user-attachments/assets/f08c675f-8482-4a59-89e1-436c2393b525" />

after

<img width="276" height="600" alt="localhost_8123_knx_info(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/1b640998-604a-450f-a2d2-3b17d6397276" />

