### PR TITLE
Only show passive address input if it is enabled

### DIFF
--- a/src/components/knx-group-address-selector.ts
+++ b/src/components/knx-group-address-selector.ts
@@ -69,7 +69,7 @@ export class GroupAddressSelector extends LitElement {
 
   private _dragOverTimeout: Record<string, NodeJS.Timeout> = {};
 
-  @query(".passive") private _passiveContainer!: HTMLDivElement;
+  @query(".passive") private _passiveContainer!: HTMLDivElement | null;
 
   @queryAll("ha-selector-select") private _gaSelectors!: NodeListOf<HTMLElement>;
 
@@ -337,6 +337,9 @@ export class GroupAddressSelector extends LitElement {
   private _togglePassiveVisibility(ev: CustomEvent) {
     ev.stopPropagation();
     ev.preventDefault();
+    if (!this._passiveContainer) {
+      return;
+    }
     const newExpanded = !this._showPassive;
     this._passiveContainer.style.overflow = "hidden";
 
@@ -345,15 +348,19 @@ export class GroupAddressSelector extends LitElement {
 
     if (!newExpanded) {
       setTimeout(() => {
-        this._passiveContainer.style.height = "0px";
+        if (this._passiveContainer) {
+          this._passiveContainer.style.height = "0px";
+        }
       }, 0);
     }
     this._showPassive = newExpanded;
   }
 
   private _handleTransitionEnd() {
-    this._passiveContainer.style.removeProperty("height");
-    this._passiveContainer.style.overflow = this._showPassive ? "initial" : "hidden";
+    if (this._passiveContainer) {
+      this._passiveContainer.style.removeProperty("height");
+      this._passiveContainer.style.overflow = this._showPassive ? "initial" : "hidden";
+    }
   }
 
   private _dragOverHandler(ev: DragEvent) {


### PR DESCRIPTION
A group address selector can disable it's `write` and `read` address, in which case the corresponding inputs are hidden.

The selector can also diable the `passive` address (e.g. `GASelector(passive=False)`), but in this case the inputs stay visible. There are currently no `GASelectors` that disable the passive address, but I think this is an oversight and I'm in the process of adding a selector that does disable the passive address and I would like it not to show.

### Example

For the following input
```python
GASelector(
    passive=False, write_required=True, valid_dpt="11.001"
)
```
| Before | With these changes |
|--------|--------|
| <img width="708" height="296" alt="Visible and expanded passive address input" src="https://github.com/user-attachments/assets/0d7ca93e-45a2-467d-a53b-87031c6b60ab" /> | <img width="698" height="235" alt="Hidden passive address input" src="https://github.com/user-attachments/assets/f6927116-ffc4-4ab1-be27-1ce60a7dc26a" /> |