### PR TITLE
Test expose value template rendering

### DIFF
--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -31,6 +31,12 @@ module.exports.definedVars = ({ isProdBuild, latestBuild, defineOverlay }) => ({
   __SUPERVISOR__: false,
   __BACKWARDS_COMPAT__: false,
   __STATIC_PATH__: "/static/",
+  __HASS_URL__: `\`${
+    "HASS_URL" in process.env
+      ? process.env.HASS_URL
+      : // eslint-disable-next-line no-template-curly-in-string
+        "${location.protocol}//${location.host}"
+  }\``,
   "process.env.NODE_ENV": JSON.stringify(isProdBuild ? "production" : "development"),
   ...defineOverlay,
 });

--- a/src/knx-router.ts
+++ b/src/knx-router.ts
@@ -1,4 +1,9 @@
-import { mdiNetwork, mdiFolderMultipleOutline, mdiFileTreeOutline } from "@mdi/js";
+import {
+  mdiNetwork,
+  mdiFolderMultipleOutline,
+  mdiFileTreeOutline,
+  mdiHomeExportOutline,
+} from "@mdi/js";
 import { customElement, property } from "lit/decorators";
 
 import type { RouterOptions } from "@ha/layouts/hass-router-page";
@@ -39,6 +44,11 @@ const knxMainTabs = (hasProject: boolean): PageNavigation[] => [
     path: `${BASE_URL}/entities`,
     iconPath: mdiFileTreeOutline,
   },
+  {
+    translationKey: "expose_view_title",
+    path: `${BASE_URL}/expose`,
+    iconPath: mdiHomeExportOutline,
+  },
 ];
 
 @customElement("knx-router")
@@ -78,6 +88,13 @@ export class KnxRouter extends HassRouterPage {
         load: () => {
           logger.debug("Importing knx-entities-view");
           return import("./views/entities_router");
+        },
+      },
+      expose: {
+        tag: "knx-expose-router",
+        load: () => {
+          logger.debug("Importing knx-expose-view");
+          return import("./views/expose_router");
         },
       },
       error: {

--- a/src/views/expose_create.ts
+++ b/src/views/expose_create.ts
@@ -1,0 +1,432 @@
+import { mdiPlus, mdiFloppy } from "@mdi/js";
+import type { TemplateResult, PropertyValues } from "lit";
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property, state, query } from "lit/decorators";
+import { ContextProvider } from "@lit/context";
+
+import "@ha/layouts/hass-loading-screen";
+import "@ha/layouts/hass-subpage";
+import "@ha/components/ha-alert";
+import "@ha/components/ha-card";
+import "@ha/components/ha-fab";
+import "@ha/components/ha-svg-icon";
+import "@ha/components/ha-navigation-list";
+import "@ha/components/ha-selector/ha-selector";
+import { navigate } from "@ha/common/navigate";
+import { mainWindow } from "@ha/common/dom/get_main_window";
+import { fireEvent } from "@ha/common/dom/fire_event";
+import { throttle } from "@ha/common/util/throttle";
+import type { HomeAssistant, ValueChangedEvent, Route } from "@ha/types";
+import { subscribeRenderTemplate } from "@ha/data/ws-templates";
+import "../components/knx-configure-entity";
+import "../components/knx-project-device-tree";
+import type { UnsubscribeFunc } from "home-assistant-js-websocket";
+import {
+  createEntity,
+  updateEntity,
+  getEntityConfig,
+  validateEntity,
+} from "services/websocket.service";
+import type { ErrorDescription, CreateEntityResult } from "types/entity_data";
+
+import { dragDropContext, DragDropContext } from "../utils/drag-drop-context";
+import { KNXLogger } from "../tools/knx-logger";
+import type { KNX } from "../types/knx";
+
+const logger = new KNXLogger("knx-create-entity");
+
+@customElement("knx-create-expose")
+export class KNXCreateExpose extends LitElement {
+  @property({ type: Object }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public knx!: KNX;
+
+  @property({ type: Object }) public route!: Route;
+
+  @property({ type: Boolean, reflect: true }) public narrow!: boolean;
+
+  @property({ type: String, attribute: "back-path" }) public backPath?: string;
+
+  @state() private _config?;
+
+  @state() private _loading = false;
+
+  @state() private _validationErrors?: ErrorDescription[];
+
+  @state() private _validationBaseError?: string;
+
+  @query("ha-alert") private _alertElement!: HTMLDivElement;
+
+  private _intent?: "create" | "edit";
+
+  private entityPlatform?: string;
+
+  @state() private entityId?: string; // only used for "edit" intent
+
+  @state() private _templateResult?: string;
+
+  @state() private _unsubRenderTemplate?: Promise<UnsubscribeFunc>;
+
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    this._unsubscribeTemplate();
+  }
+
+  private _dragDropContextProvider = new ContextProvider(this, {
+    context: dragDropContext,
+    initialValue: new DragDropContext(() => {
+      this._dragDropContextProvider.updateObservers();
+    }),
+  });
+
+  protected firstUpdated() {
+    if (!this.knx.project) {
+      this.knx.loadProject().then(() => {
+        this.requestUpdate();
+      });
+    }
+  }
+
+  protected willUpdate(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has("route")) {
+      const intent = this.route.prefix.split("/").at(-1);
+      if (intent === "create" || intent === "edit") {
+        this._intent = intent;
+      } else {
+        logger.error("Unknown intent", intent);
+        this._intent = undefined;
+        return;
+      }
+
+      if (intent === "create") {
+        // knx/entities/create -> path: ""; knx/entities/create/ -> path: "/"
+        // knx/entities/create/light -> path: "/light"
+        const entityPlatform = this.route.path.split("/")[1];
+        this.entityPlatform = entityPlatform;
+        this._config = undefined; // clear config - eg. when `back` was used
+        this._validationErrors = undefined; // clear validation errors - eg. when `back` was used
+        this._validationBaseError = undefined;
+        this._loading = false;
+      } else if (intent === "edit") {
+        // knx/entities/edit/light.living_room -> path: "/light.living_room"
+        this.entityId = this.route.path.split("/")[1];
+        this._loading = true;
+        getEntityConfig(this.hass, this.entityId)
+          .then((entityConfigData) => {
+            const { platform: entityPlatform, data: config } = entityConfigData;
+            this.entityPlatform = entityPlatform;
+            this._config = config;
+          })
+          .catch((err) => {
+            logger.warn("Fetching entity config failed.", err);
+            this.entityPlatform = undefined; // used as error marker
+          })
+          .finally(() => {
+            this._loading = false;
+          });
+      }
+    }
+  }
+
+  protected render(): TemplateResult {
+    // if (!this.hass || !this.knx.project || !this._intent || this._loading) {
+    //   return html` <hass-loading-screen></hass-loading-screen> `;
+    // }
+    return this._renderEntityConfig(this._intent !== "edit");
+  }
+
+  private _renderEntityConfig(create: boolean): TemplateResult {
+    if (this.entityId) {
+      console.log("entity", this.hass.entities[this.entityId]);
+    }
+    return html`<hass-subpage
+      .hass=${this.hass}
+      .narrow=${this.narrow!}
+      .back-path=${this.backPath}
+      .header=${create ? "Create new expose" : `Edit ${this.entityId}`}
+    >
+      <div class="content">
+        <div class="entity-config">
+          <div class="knx-configure-expose">
+            <ha-selector
+              .key=${"entity_id"}
+              .hass=${this.hass}
+              .label=${"Entity"}
+              .selector=${{ entity: null }}
+              .value=${this._config?.entity_id}
+              @value-changed=${this._updateConfig}
+            ></ha-selector>
+            <ha-selector
+              .key=${"attribute"}
+              .hass=${this.hass}
+              .label=${"Attribute"}
+              .selector=${{ attribute: { entity_id: this._config?.entity_id } }}
+              .value=${this._config?.attribute}
+              @value-changed=${this._updateConfig}
+            ></ha-selector>
+            ${this.entityId
+              ? html` <p>Value: ${this.hass.states[this.entityId]?.state}</p> `
+              : nothing}
+            <ha-selector
+              .key=${"value_template"}
+              .hass=${this.hass}
+              .label=${"Value Template"}
+              .selector=${{ template: null }}
+              .value=${this._config?.value_template}
+              @value-changed=${this._updateConfig}
+            ></ha-selector>
+            ${this._config?.value_template
+              ? html`
+                  <p>Value Template: ${this._config?.value_template}</p>
+                  <p>Result: ${this._templateResult}</p>
+                `
+              : nothing}
+          </div>
+          <ha-fab
+            .label=${create ? "Create" : "Save"}
+            extended
+            @click=${create ? this._entityCreate : this._entityUpdate}
+            ?disabled=${this._config === undefined}
+          >
+            <ha-svg-icon slot="icon" .path=${create ? mdiPlus : mdiFloppy}></ha-svg-icon>
+          </ha-fab>
+        </div>
+        ${this.knx.project?.project_loaded
+          ? html` <div class="panel">
+              <knx-project-device-tree
+                .data=${this.knx.project.knxproject}
+                .validDPTs=${undefined}
+              ></knx-project-device-tree>
+            </div>`
+          : nothing}
+      </div>
+    </hass-subpage>`;
+  }
+
+  private async _updateConfig(ev: ValueChangedEvent<any>) {
+    ev.stopPropagation();
+    const key = ev.target.key;
+    const value = ev.detail.value;
+    // TODO: use nested-set and nested-get helpers to remove when empty
+    if (this._config === undefined) {
+      this._config = {};
+    }
+    this._config[key] = value;
+    logger.debug(`Config updated ${key}: ${value}`, this._config);
+    await this._updateValueTemplate();
+    this.requestUpdate();
+  }
+
+  private async _updateValueTemplate() {
+    await this._unsubscribeTemplate();
+    this._templateResult = undefined;
+    console.log("Updating value template for", this._config?.value_template);
+    if (this._config?.value_template) {
+      const value = this._config.attribute
+        ? this.hass.states[this._config.entity_id]?.attributes[this._config.attribute]
+        : this.hass.states[this._config.entity_id]?.state || "";
+      console.log("Updating value template", this._config.value_template, value);
+      this._unsubRenderTemplate = subscribeRenderTemplate(
+        this.hass.connection,
+        (result) => {
+          if ("error" in result) {
+            logger.error("Template render error", result.error);
+            // TODO: proper error in UI
+            this._templateResult = "Error rendering template";
+            return;
+          }
+          this._templateResult = result.result;
+        },
+        {
+          template: this._config.value_template,
+          timeout: 3,
+          report_errors: true,
+          variables: { value },
+        },
+      );
+      await this._unsubRenderTemplate;
+    }
+  }
+
+  private async _unsubscribeTemplate(): Promise<void> {
+    if (!this._unsubRenderTemplate) {
+      return;
+    }
+
+    try {
+      const unsub = await this._unsubRenderTemplate;
+      unsub();
+      this._unsubRenderTemplate = undefined;
+    } catch (err: any) {
+      if (err.code === "not_found") {
+        // If we get here, the connection was probably already closed. Ignore.
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  private _configChanged(ev) {
+    ev.stopPropagation();
+    logger.debug("configChanged", ev.detail);
+    this._config = ev.detail;
+    if (this._validationErrors) {
+      this._entityValidate();
+    }
+  }
+
+  private _entityValidate = throttle(() => {
+    logger.debug("validate", this._config);
+    if (this._config === undefined || this.entityPlatform === undefined) return;
+    validateEntity(this.hass, { platform: this.entityPlatform, data: this._config })
+      .then((createEntityResult) => {
+        this._handleValidationError(createEntityResult, false);
+      })
+      .catch((err) => {
+        logger.error("validateEntity", err);
+        navigate("/knx/error", { replace: true, data: err });
+      });
+  }, 250);
+
+  private _entityCreate(ev) {
+    ev.stopPropagation();
+    if (this._config === undefined || this.entityPlatform === undefined) {
+      logger.error("No config found.");
+      return;
+    }
+    createEntity(this.hass, { platform: this.entityPlatform, data: this._config })
+      .then((createEntityResult) => {
+        if (this._handleValidationError(createEntityResult, true)) return;
+        logger.debug("Successfully created entity", createEntityResult.entity_id);
+        navigate("/knx/entities", { replace: true });
+        if (!createEntityResult.entity_id) {
+          logger.error("entity_id not found after creation.");
+          return;
+        }
+        this._entityMoreInfoSettings(createEntityResult.entity_id);
+      })
+      .catch((err) => {
+        logger.error("Error creating entity", err);
+        navigate("/knx/error", { replace: true, data: err });
+      });
+  }
+
+  private _entityUpdate(ev) {
+    ev.stopPropagation();
+    if (
+      this._config === undefined ||
+      this.entityId === undefined ||
+      this.entityPlatform === undefined
+    ) {
+      logger.error("No config found.");
+      return;
+    }
+    updateEntity(this.hass, {
+      platform: this.entityPlatform,
+      entity_id: this.entityId,
+      data: this._config,
+    })
+      .then((createEntityResult) => {
+        if (this._handleValidationError(createEntityResult, true)) return;
+        logger.debug("Successfully updated entity", this.entityId);
+        navigate("/knx/entities", { replace: true });
+      })
+      .catch((err) => {
+        logger.error("Error updating entity", err);
+        navigate("/knx/error", { replace: true, data: err });
+      });
+  }
+
+  private _handleValidationError(result: CreateEntityResult, final: boolean): boolean {
+    // return true if validation error; scroll to alert if final
+    if (result.success === false) {
+      logger.warn("Validation error", result);
+      this._validationErrors = result.errors;
+      this._validationBaseError = result.error_base;
+      if (final) {
+        setTimeout(() => this._alertElement.scrollIntoView({ behavior: "smooth" }));
+      }
+      return true;
+    }
+    this._validationErrors = undefined;
+    this._validationBaseError = undefined;
+    logger.debug("Validation passed", result.entity_id);
+    return false;
+  }
+
+  private _entityMoreInfoSettings(entityId: string) {
+    fireEvent(mainWindow.document.querySelector("home-assistant")!, "hass-more-info", {
+      entityId,
+      view: "settings",
+    });
+  }
+
+  static styles = css`
+    hass-loading-screen {
+      --app-header-background-color: var(--sidebar-background-color);
+      --app-header-text-color: var(--sidebar-text-color);
+    }
+
+    .type-selection {
+      margin: 20px auto 80px;
+      max-width: 720px;
+    }
+
+    @media screen and (max-width: 600px) {
+      .panel {
+        display: none;
+      }
+    }
+
+    .content {
+      display: flex;
+      flex-direction: row;
+      height: 100%;
+      width: 100%;
+
+      & > .entity-config {
+        flex-grow: 1;
+        flex-shrink: 1;
+        height: 100%;
+        overflow-y: scroll;
+      }
+
+      & > .panel {
+        flex-grow: 0;
+        flex-shrink: 3;
+        width: 480px;
+        min-width: 280px;
+      }
+    }
+
+    .knx-configure-expose {
+      display: block;
+      margin: 20px auto 40px; /* leave 80px space for fab */
+      max-width: 720px;
+    }
+
+    ha-alert {
+      display: block;
+      margin: 20px auto;
+      max-width: 720px;
+
+      & summary {
+        padding: 10px;
+      }
+    }
+
+    ha-fab {
+      /* not slot="fab" to move out of panel */
+      float: right;
+      margin-right: calc(16px + env(safe-area-inset-right));
+      margin-bottom: 40px;
+      z-index: 1;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "knx-create-expose": KNXCreateExpose;
+  }
+}

--- a/src/views/expose_router.ts
+++ b/src/views/expose_router.ts
@@ -1,0 +1,45 @@
+import { customElement } from "lit/decorators";
+
+import type { RouterOptions } from "@ha/layouts/hass-router-page";
+
+import { KnxRouter } from "../knx-router";
+import { KNXLogger } from "../tools/knx-logger";
+
+const logger = new KNXLogger("router");
+
+@customElement("knx-expose-router")
+class KnxExposeRouter extends KnxRouter {
+  protected routerOptions: RouterOptions = {
+    defaultPage: "view",
+    beforeRender: (page: string) => (page === "" ? this.routerOptions.defaultPage : undefined),
+    routes: {
+      view: {
+        tag: "knx-expose-view",
+        load: () => {
+          logger.debug("Importing knx-entities-view");
+          return import("./expose_view");
+        },
+      },
+      create: {
+        tag: "knx-create-expose",
+        load: () => {
+          logger.debug("Importing knx-create-expose");
+          return import("./expose_create");
+        },
+      },
+      edit: {
+        tag: "knx-create-expose",
+        load: () => {
+          logger.debug("Importing knx-create-expose");
+          return import("./expose_create");
+        },
+      },
+    },
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "knx-expose-router": KnxExposeRouter;
+  }
+}

--- a/src/views/expose_view.ts
+++ b/src/views/expose_view.ts
@@ -1,0 +1,267 @@
+import {
+  mdiDelete,
+  mdiInformationSlabCircleOutline,
+  mdiInformationOffOutline,
+  mdiPlus,
+  mdiPencilOutline,
+} from "@mdi/js";
+import type { TemplateResult } from "lit";
+import { LitElement, html, css } from "lit";
+import { customElement, property, state } from "lit/decorators";
+
+import type { HassEntity } from "home-assistant-js-websocket";
+import memoize from "memoize-one";
+
+import "@ha/layouts/hass-loading-screen";
+import "@ha/layouts/hass-tabs-subpage-data-table";
+import "@ha/components/ha-fab";
+import "@ha/components/ha-icon";
+import "@ha/components/ha-icon-button";
+import "@ha/components/ha-state-icon";
+import "@ha/components/ha-svg-icon";
+import { navigate } from "@ha/common/navigate";
+import { mainWindow } from "@ha/common/dom/get_main_window";
+import { fireEvent } from "@ha/common/dom/fire_event";
+import type { DataTableColumnContainer } from "@ha/components/data-table/ha-data-table";
+import type { ExtEntityRegistryEntry } from "@ha/data/entity_registry";
+import { showAlertDialog, showConfirmationDialog } from "@ha/dialogs/generic/show-dialog-box";
+import type { PageNavigation } from "@ha/layouts/hass-tabs-subpage";
+import type { HomeAssistant, Route } from "@ha/types";
+
+import { getEntityEntries, deleteEntity } from "../services/websocket.service";
+import type { KNX } from "../types/knx";
+import { KNXLogger } from "../tools/knx-logger";
+
+const logger = new KNXLogger("knx-entities-view");
+
+export interface EntityRow extends ExtEntityRegistryEntry {
+  entityState?: HassEntity;
+  friendly_name: string;
+  device_name: string;
+  area_name: string;
+  disabled: boolean;
+}
+
+@customElement("knx-expose-view")
+export class KNXExposeView extends LitElement {
+  @property({ type: Object }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public knx!: KNX;
+
+  @property({ type: Boolean, reflect: true }) public narrow!: boolean;
+
+  @property({ type: Object }) public route?: Route;
+
+  @property({ type: Array, reflect: false }) public tabs!: PageNavigation[];
+
+  @state() private knx_entities: EntityRow[] = [];
+
+  @state() private filterDevice: string | null = null;
+
+  protected firstUpdated() {
+    this._fetchEntities();
+  }
+
+  protected willUpdate() {
+    const urlParams = new URLSearchParams(mainWindow.location.search);
+    this.filterDevice = urlParams.get("device_id");
+  }
+
+  private async _fetchEntities() {
+    getEntityEntries(this.hass)
+      .then((entries) => {
+        logger.debug(`Fetched ${entries.length} entity entries.`);
+        this.knx_entities = entries.map((entry) => {
+          const entityState: HassEntity | undefined = this.hass.states[entry.entity_id]; // undefined for disabled entities
+          const device = entry.device_id ? this.hass.devices[entry.device_id] : undefined;
+          const areaId = entry.area_id ?? device?.area_id;
+          const area = areaId ? this.hass.areas[areaId] : undefined;
+          return {
+            ...entry,
+            entityState,
+            friendly_name:
+              entityState?.attributes.friendly_name ?? entry.name ?? entry.original_name ?? "",
+            device_name: device?.name ?? "",
+            area_name: area?.name ?? "",
+            disabled: !!entry.disabled_by,
+          };
+        });
+      })
+      .catch((err) => {
+        logger.error("getEntityEntries", err);
+        navigate("/knx/error", { replace: true, data: err });
+      });
+  }
+
+  private _columns = memoize((_language): DataTableColumnContainer<EntityRow> => {
+    const iconWidth = "56px";
+    const actionWidth = "176px"; // 48px*3 + 16px*2 padding
+
+    return {
+      icon: {
+        title: "",
+        minWidth: iconWidth,
+        maxWidth: iconWidth,
+        type: "icon",
+        template: (entry) =>
+          entry.disabled
+            ? html`<ha-svg-icon
+                slot="icon"
+                label="Disabled entity"
+                .path=${mdiInformationOffOutline}
+                style="color: var(--disabled-text-color);"
+              ></ha-svg-icon>`
+            : html`
+                <ha-state-icon
+                  slot="item-icon"
+                  .hass=${this.hass}
+                  .stateObj=${entry.entityState}
+                ></ha-state-icon>
+              `,
+      },
+      friendly_name: {
+        showNarrow: true,
+        filterable: true,
+        sortable: true,
+        title: "Friendly Name",
+        flex: 2,
+        // sorting didn't work properly with templates
+      },
+      entity_id: {
+        filterable: true,
+        sortable: true,
+        title: "Entity ID",
+        flex: 1,
+      },
+      device_name: {
+        filterable: true,
+        sortable: true,
+        title: "Device",
+        flex: 1,
+      },
+      device_id: {
+        hidden: true, // for filtering only
+        title: "Device ID",
+        filterable: true,
+        template: (entry) => entry.device_id ?? "",
+      },
+      area_name: {
+        title: "Area",
+        sortable: true,
+        filterable: true,
+        flex: 1,
+      },
+      actions: {
+        showNarrow: true,
+        title: "",
+        minWidth: actionWidth,
+        maxWidth: actionWidth,
+        type: "icon-button",
+        template: (entry) => html`
+          <ha-icon-button
+            .label=${"More info"}
+            .path=${mdiInformationSlabCircleOutline}
+            .entityEntry=${entry}
+            @click=${this._entityMoreInfo}
+          ></ha-icon-button>
+          <ha-icon-button
+            .label=${this.hass.localize("ui.common.edit")}
+            .path=${mdiPencilOutline}
+            .entityEntry=${entry}
+            @click=${this._entityEdit}
+          ></ha-icon-button>
+          <ha-icon-button
+            .label=${this.hass.localize("ui.common.delete")}
+            .path=${mdiDelete}
+            .entityEntry=${entry}
+            @click=${this._entityDelete}
+          ></ha-icon-button>
+        `,
+      },
+    };
+  });
+
+  private _entityEdit = (ev: Event) => {
+    ev.stopPropagation();
+    const entry = ev.target.entityEntry as EntityRow;
+    navigate("/knx/entities/edit/" + entry.entity_id);
+  };
+
+  private _entityMoreInfo = (ev: Event) => {
+    ev.stopPropagation();
+    const entry = ev.target.entityEntry as EntityRow;
+    fireEvent(mainWindow.document.querySelector("home-assistant")!, "hass-more-info", {
+      entityId: entry.entity_id,
+    });
+  };
+
+  private _entityDelete = (ev: Event) => {
+    ev.stopPropagation();
+    const entry = ev.target.entityEntry as EntityRow;
+    showConfirmationDialog(this, {
+      text: `${this.hass.localize("ui.common.delete")} ${entry.entity_id}?`,
+    }).then((confirmed) => {
+      if (confirmed) {
+        deleteEntity(this.hass, entry.entity_id)
+          .then(() => {
+            logger.debug("entity deleted", entry.entity_id);
+            this._fetchEntities();
+          })
+          .catch((err: any) => {
+            showAlertDialog(this, {
+              title: "Deletion failed",
+              text: err,
+            });
+          });
+      }
+    });
+  };
+
+  protected render(): TemplateResult {
+    if (!this.hass || !this.knx_entities) {
+      return html` <hass-loading-screen></hass-loading-screen> `;
+    }
+
+    return html`
+      <hass-tabs-subpage-data-table
+        .hass=${this.hass}
+        .narrow=${this.narrow}
+        .route=${this.route!}
+        .tabs=${this.tabs}
+        .localizeFunc=${this.knx.localize}
+        .columns=${this._columns(this.hass.language)}
+        .data=${this.knx_entities}
+        .hasFab=${true}
+        .searchLabel=${this.hass.localize("ui.components.data-table.search")}
+        .clickable=${false}
+        .filter=${this.filterDevice}
+      >
+        <ha-fab
+          slot="fab"
+          .label=${this.hass.localize("ui.common.add")}
+          extended
+          @click=${this._exposeCreate}
+        >
+          <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
+        </ha-fab>
+      </hass-tabs-subpage-data-table>
+    `;
+  }
+
+  private _exposeCreate() {
+    navigate("/knx/expose/create");
+  }
+
+  static styles = css`
+    hass-loading-screen {
+      --app-header-background-color: var(--sidebar-background-color);
+      --app-header-text-color: var(--sidebar-text-color);
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "knx-expose-view": KNXExposeView;
+  }
+}


### PR DESCRIPTION
@Abestanis Hi 👋! 
This was my initial idea of setting up expose selectors and getting `value_template` to work with preview. Maybe it is of any help for you.

 It's a very rough copy of the entity creation page... so the only thing interesting here is `/knx/expose/create` to see the template stuff working (adding `__HASS_URL__` to build-scripts was necessary for this). And maybe the router stuff.
No backend changes are required.