### PR TITLE
Fix GA selector initialized with null

### DIFF
--- a/src/components/knx-group-address-selector.ts
+++ b/src/components/knx-group-address-selector.ts
@@ -210,7 +210,7 @@ export class GroupAddressSelector extends LitElement {
                   select: { multiple: false, custom_value: true, options: this.addressOptions },
                 }}
                 .key=${"write"}
-                .value=${this.config.write}
+                .value=${this.config.write ?? undefined}
                 @value-changed=${this._updateConfig}
                 @dragover=${this._dragOverHandler}
                 @drop=${this._dropHandler}
@@ -230,7 +230,7 @@ export class GroupAddressSelector extends LitElement {
                   select: { multiple: false, custom_value: true, options: this.addressOptions },
                 }}
                 .key=${"state"}
-                .value=${this.config.state}
+                .value=${this.config.state ?? undefined}
                 @value-changed=${this._updateConfig}
                 @dragover=${this._dragOverHandler}
                 @drop=${this._dropHandler}

--- a/src/types/entity_data.ts
+++ b/src/types/entity_data.ts
@@ -3,9 +3,9 @@ export type EntityCategory = "config" | "diagnostic";
 export type SupportedPlatform = string;
 
 export interface GASchema {
-  write?: string;
-  state?: string;
-  passive?: string[];
+  write?: string | null; // may be null from backend if optional as it defaults to None
+  state?: string | null; // may be null from backend if optional as it defaults to None
+  passive?: string[]; // should never be null as it is removed if empty
   dpt?: string;
 }
 


### PR DESCRIPTION
when passing `null` to `ha-selector-select` we'd get an exception.
> TypeError: null is not an object (evaluating 'label.toLowerCase')