### PR TITLE
Show updated Device name if available

### DIFF
--- a/src/views/entities_view.ts
+++ b/src/views/entities_view.ts
@@ -92,7 +92,7 @@ export class KNXEntitiesView extends SubscribeMixin(LitElement) {
             entityState,
             friendly_name:
               entityState?.attributes.friendly_name ?? entry.name ?? entry.original_name ?? "",
-            device_name: device?.name ?? "",
+            device_name: device?.name_by_user ?? device?.name ?? "",
             area_name: area?.name ?? "",
             disabled: !!entry.disabled_by,
           };


### PR DESCRIPTION
As mentioned on Discord, this should use the updated device name if set by the user, instead of only using the original.