### PR TITLE
Remove hardcoded back-path

### DIFF
--- a/src/features/group-monitor/views/group-monitor-view.ts
+++ b/src/features/group-monitor/views/group-monitor-view.ts
@@ -31,7 +31,7 @@ import type { TelegramRow, TelegramRowKeys } from "../types/telegram-row";
 import type { ToggleFilterEvent } from "../../../components/data-table/cell/knx-table-cell-filterable";
 import { GroupMonitorController } from "../controller/group-monitor-controller";
 import type { DistinctValueInfo } from "../controller/group-monitor-controller";
-import { BASE_URL, groupMonitorTab } from "../../../knx-router";
+import { groupMonitorTab } from "../../../knx-router";
 
 import type { KNX } from "../../../types/knx";
 import type {
@@ -882,7 +882,6 @@ export class KNXGroupMonitor extends LitElement {
       <hass-tabs-subpage-data-table
         .hass=${this.hass}
         .narrow=${this.narrow!}
-        back-path=${BASE_URL}
         .tabs=${[groupMonitorTab]}
         .route=${this.route!}
         .columns=${this._columns(

--- a/src/views/entities_view.ts
+++ b/src/views/entities_view.ts
@@ -32,7 +32,7 @@ import type { HomeAssistant, Route } from "@ha/types";
 
 import { getEntityEntries, deleteEntity, getEntityConfig } from "../services/websocket.service";
 import type { KNX } from "../types/knx";
-import { BASE_URL, entitiesTab } from "../knx-router";
+import { entitiesTab } from "../knx-router";
 import { KNXLogger } from "../tools/knx-logger";
 
 const logger = new KNXLogger("knx-entities-view");
@@ -282,7 +282,6 @@ export class KNXEntitiesView extends SubscribeMixin(LitElement) {
       <hass-tabs-subpage-data-table
         .hass=${this.hass}
         .narrow=${this.narrow}
-        back-path=${BASE_URL}
         .route=${this.route!}
         .tabs=${[entitiesTab]}
         .localizeFunc=${this.knx.localize}

--- a/src/views/info.ts
+++ b/src/views/info.ts
@@ -16,7 +16,7 @@ import type { KNX } from "../types/knx";
 import type { KNXProjectInfo } from "../types/websocket";
 import { KNXLogger } from "../tools/knx-logger";
 import { VERSION } from "../version";
-import { BASE_URL, infoTab } from "../knx-router";
+import { infoTab } from "../knx-router";
 
 const logger = new KNXLogger("info");
 
@@ -35,7 +35,6 @@ export class KNXInfo extends LitElement {
       <hass-subpage
         .hass=${this.hass}
         .narrow=${this.narrow!}
-        back-path=${BASE_URL}
         .header=${this.knx.localize(infoTab.translationKey)}
       >
         <div class="columns">

--- a/src/views/project_view.ts
+++ b/src/views/project_view.ts
@@ -26,7 +26,7 @@ import { compare } from "compare-versions";
 import type { HomeAssistant, Route } from "@ha/types";
 import { dptInClasses } from "utils/dpt";
 import type { KNX } from "../types/knx";
-import { BASE_URL, projectTab } from "../knx-router";
+import { projectTab } from "../knx-router";
 import type { GroupRangeSelectionChangedEvent } from "../components/knx-project-tree-view";
 import { subscribeKnxTelegrams, getGroupTelegrams } from "../services/websocket.service";
 import type { GroupAddress, TelegramDict } from "../types/websocket";
@@ -243,7 +243,6 @@ export class KNXProjectView extends LitElement {
     return html` <hass-tabs-subpage
       .hass=${this.hass}
       .narrow=${this.narrow!}
-      back-path=${BASE_URL}
       .route=${this.route!}
       .tabs=${[projectTab]}
       .localizeFunc=${this.knx.localize}


### PR DESCRIPTION
Use browser history stack instead of hardcoded back-path.

The back button previously added to the history-stack. When "back" was used two times (subpage, dashboard), it behaved like "back" - "forward".

fixes #310