### PR TITLE
Group monitor: Add context time span filter

### DIFF
--- a/src/components/data-table/filter/knx-time-delta-filter.ts
+++ b/src/components/data-table/filter/knx-time-delta-filter.ts
@@ -1,0 +1,287 @@
+/**
+ * KNX Time-Delta Context Filter Component
+ *
+ * A filter panel that allows users to specify a time window (in milliseconds)
+ * around filter-matching telegrams. When active, telegrams within ±delta of
+ * any matching telegram are included in results, even if they don't match
+ * the other active filters (source, destination, type, direction).
+ *
+ * This is only enabled when at least one other filter is active.
+ */
+
+import type { TemplateResult } from "lit";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+
+import "@ha/components/ha-expansion-panel";
+import "@ha/components/ha-textfield";
+import { fireEvent } from "@ha/common/dom/fire_event";
+
+import "../../flex-content-expansion-panel";
+import type { KNX } from "../../../types/knx";
+
+// ============================================================================
+// Event Interfaces
+// ============================================================================
+
+/**
+ * Event payload for time-delta value changes
+ */
+export interface TimeDeltaChangedEvent {
+  /** Milliseconds before a matching telegram */
+  deltaBefore: number;
+  /** Milliseconds after a matching telegram */
+  deltaAfter: number;
+}
+
+/**
+ * Event payload for expansion state changes
+ */
+export interface TimeDeltaExpandedChangedEvent {
+  /** Whether the panel is now expanded */
+  expanded: boolean;
+}
+
+@customElement("knx-time-delta-filter")
+export class KnxTimeDeltaFilter extends LitElement {
+  /**
+   * KNX integration instance providing localization
+   */
+  @property({ attribute: false }) public knx!: KNX;
+
+  /**
+   * Current expansion state of the filter panel
+   */
+  @property({ type: Boolean, reflect: true }) public expanded = false;
+
+  /**
+   * Milliseconds before a matching telegram to include
+   */
+  @property({ type: Number, attribute: "delta-before" }) public deltaBefore = 0;
+
+  /**
+   * Milliseconds after a matching telegram to include
+   */
+  @property({ type: Number, attribute: "delta-after" }) public deltaAfter = 0;
+
+  /**
+   * Whether the filter is disabled (no other filters active)
+   */
+  @property({ type: Boolean }) public disabled = false;
+
+  // ============================================================================
+  // Event Handlers
+  // ============================================================================
+
+  private _expandedChanged(ev: CustomEvent<{ expanded: boolean }>): void {
+    this.expanded = ev.detail.expanded;
+    fireEvent(this, "expanded-changed", { expanded: this.expanded });
+  }
+
+  private _handleBeforeInput(ev: InputEvent): void {
+    const target = ev.target as HTMLInputElement;
+    const value = Math.max(0, Math.floor(Number(target.value) || 0));
+    if (value !== this.deltaBefore) {
+      this.deltaBefore = value;
+      this._fireTimeDeltaChanged();
+    }
+  }
+
+  private _handleAfterInput(ev: InputEvent): void {
+    const target = ev.target as HTMLInputElement;
+    const value = Math.max(0, Math.floor(Number(target.value) || 0));
+    if (value !== this.deltaAfter) {
+      this.deltaAfter = value;
+      this._fireTimeDeltaChanged();
+    }
+  }
+
+  private _fireTimeDeltaChanged(): void {
+    fireEvent(this, "time-delta-changed", {
+      deltaBefore: this.deltaBefore,
+      deltaAfter: this.deltaAfter,
+    });
+  }
+
+  // ============================================================================
+  // Render
+  // ============================================================================
+
+  protected render(): TemplateResult {
+    const headerText = this.knx.localize("group_monitor_time_delta_title");
+    const hasValues = this.deltaBefore > 0 || this.deltaAfter > 0;
+
+    return html`
+      <flex-content-expansion-panel
+        leftChevron
+        .expanded=${this.expanded}
+        @expanded-changed=${this._expandedChanged}
+      >
+        <div slot="header" class="header">
+          <span class="title">
+            ${headerText}
+            ${hasValues && !this.disabled ? html`<div class="badge">●</div>` : nothing}
+          </span>
+        </div>
+
+        ${this.expanded
+          ? html`
+              <div class="filter-content">
+                <p class="description">
+                  ${this.knx.localize("group_monitor_time_delta_description")}
+                </p>
+
+                ${this.disabled
+                  ? html`
+                      <p class="disabled-message">
+                        ${this.knx.localize("group_monitor_time_delta_disabled")}
+                      </p>
+                    `
+                  : html`
+                      <div class="input-row">
+                        <label class="input-label">
+                          ${this.knx.localize("group_monitor_time_delta_before")}
+                        </label>
+                        <div class="input-wrapper">
+                          <ha-textfield
+                            type="number"
+                            .value=${this.deltaBefore.toString()}
+                            .placeholder=${this.knx.localize(
+                              "group_monitor_time_delta_placeholder",
+                            )}
+                            min="0"
+                            .disabled=${this.disabled}
+                            @change=${this._handleBeforeInput}
+                            suffix="ms"
+                          ></ha-textfield>
+                        </div>
+                      </div>
+
+                      <div class="input-row">
+                        <label class="input-label">
+                          ${this.knx.localize("group_monitor_time_delta_after")}
+                        </label>
+                        <div class="input-wrapper">
+                          <ha-textfield
+                            type="number"
+                            .value=${this.deltaAfter.toString()}
+                            .placeholder=${this.knx.localize(
+                              "group_monitor_time_delta_placeholder",
+                            )}
+                            min="0"
+                            .disabled=${this.disabled}
+                            @change=${this._handleAfterInput}
+                            suffix="ms"
+                          ></ha-textfield>
+                        </div>
+                      </div>
+                    `}
+              </div>
+            `
+          : nothing}
+      </flex-content-expansion-panel>
+    `;
+  }
+
+  // ============================================================================
+  // Styles
+  // ============================================================================
+
+  static readonly styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      border-bottom: 1px solid var(--divider-color);
+    }
+
+    flex-content-expansion-panel {
+      --ha-card-border-radius: 0;
+      --expansion-panel-content-padding: 0;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+    }
+
+    .title {
+      display: flex;
+      align-items: center;
+      font-weight: 500;
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-left: 8px;
+      font-size: 10px;
+      color: var(--primary-color);
+    }
+
+    .filter-content {
+      display: flex;
+      flex-direction: column;
+      padding: 0 16px 16px;
+    }
+
+    .description {
+      color: var(--secondary-text-color);
+      font-size: 0.85em;
+      margin: 4px 0 12px;
+      line-height: 1.4;
+    }
+
+    .disabled-message {
+      color: var(--secondary-text-color);
+      font-size: 0.85em;
+      font-style: italic;
+      margin: 0 0 8px;
+      padding: 8px 12px;
+      background: rgba(var(--rgb-primary-text-color), 0.04);
+      border-radius: 8px;
+    }
+
+    .input-row {
+      display: flex;
+      flex-direction: column;
+      margin-bottom: 8px;
+    }
+
+    .input-label {
+      font-size: 0.8em;
+      font-weight: 500;
+      color: var(--secondary-text-color);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 4px;
+    }
+
+    .input-wrapper {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    ha-textfield {
+      flex: 1;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "knx-time-delta-filter": KnxTimeDeltaFilter;
+  }
+
+  // for fire event
+  interface HASSDomEvents {
+    "time-delta-changed": TimeDeltaChangedEvent;
+  }
+}

--- a/src/components/data-table/filter/knx-time-delta-filter.ts
+++ b/src/components/data-table/filter/knx-time-delta-filter.ts
@@ -39,11 +39,6 @@ export interface TimeDeltaChangedEvent {
 /**
  * Event payload for expansion state changes
  */
-export interface TimeDeltaExpandedChangedEvent {
-  /** Whether the panel is now expanded */
-  expanded: boolean;
-}
-
 @customElement("knx-time-delta-filter")
 export class KnxTimeDeltaFilter extends LitElement {
   @property({ attribute: false, hasChanged: () => false }) public hass!: HomeAssistant;

--- a/src/components/data-table/filter/knx-time-delta-filter.ts
+++ b/src/components/data-table/filter/knx-time-delta-filter.ts
@@ -46,7 +46,7 @@ export interface TimeDeltaExpandedChangedEvent {
 
 @customElement("knx-time-delta-filter")
 export class KnxTimeDeltaFilter extends LitElement {
-  @property({ attribute: false }) public hass!: HomeAssistant;
+  @property({ attribute: false, hasChanged: () => false }) public hass!: HomeAssistant;
 
   /**
    * KNX integration instance providing localization
@@ -155,6 +155,67 @@ export class KnxTimeDeltaFilter extends LitElement {
         ${this.expanded
           ? html`
               <div class="filter-content">
+                <p class="description">
+                  ${this.knx.localize("group_monitor_time_delta_description")}
+                </p>
+
+                ${this.disabled
+                  ? html`
+                      <p class="disabled-message">
+                        ${this.knx.localize("group_monitor_time_delta_disabled")}
+                      </p>
+                    `
+                  : html`
+                      <div class="input-row">
+                        <div
+                          class="input-wrapper"
+                          title=${this.knx.localize("group_monitor_time_delta_before")}
+                        >
+                          <ha-selector-number
+                            id="delta-before"
+                            .hass=${this.hass}
+                            .value=${this.deltaBefore}
+                            .disabled=${this.disabled}
+                            .required=${false}
+                            .label=${this.knx.localize("group_monitor_time_delta_before")}
+                            .selector=${{
+                              number: {
+                                min: 0,
+                                step: 10,
+                                mode: "box",
+                                unit_of_measurement: "ms",
+                              },
+                            }}
+                            @value-changed=${this._handleBeforeInput}
+                          ></ha-selector-number>
+                        </div>
+                      </div>
+
+                      <div class="input-row">
+                        <div
+                          class="input-wrapper"
+                          title=${this.knx.localize("group_monitor_time_delta_after")}
+                        >
+                          <ha-selector-number
+                            id="delta-after"
+                            .hass=${this.hass}
+                            .value=${this.deltaAfter}
+                            .disabled=${this.disabled}
+                            .required=${false}
+                            .label=${this.knx.localize("group_monitor_time_delta_after")}
+                            .selector=${{
+                              number: {
+                                min: 0,
+                                step: 10,
+                                mode: "box",
+                                unit_of_measurement: "ms",
+                              },
+                            }}
+                            @value-changed=${this._handleAfterInput}
+                          ></ha-selector-number>
+                        </div>
+                      </div>
+                    `}
                 ${hasValues && !this.disabled
                   ? html`
                       <div class="summary-item">
@@ -172,66 +233,6 @@ export class KnxTimeDeltaFilter extends LitElement {
                       </div>
                     `
                   : nothing}
-
-                <p class="description">
-                  ${this.knx.localize("group_monitor_time_delta_description")}
-                </p>
-
-                ${this.disabled
-                  ? html`
-                      <p class="disabled-message">
-                        ${this.knx.localize("group_monitor_time_delta_disabled")}
-                      </p>
-                    `
-                  : html`
-                      <div class="input-row">
-                        <div class="input-label" aria-hidden="true">
-                          ${this.knx.localize("group_monitor_time_delta_before")}
-                        </div>
-                        <div class="input-wrapper">
-                          <ha-selector-number
-                            id="delta-before"
-                            .hass=${this.hass}
-                            .value=${this.deltaBefore}
-                            .disabled=${this.disabled}
-                            .label=${this.knx.localize("group_monitor_time_delta_before")}
-                            .selector=${{
-                              number: {
-                                min: 0,
-                                step: 10,
-                                mode: "box",
-                                unit_of_measurement: "ms",
-                              },
-                            }}
-                            @value-changed=${this._handleBeforeInput}
-                          ></ha-selector-number>
-                        </div>
-                      </div>
-
-                      <div class="input-row">
-                        <div class="input-label" aria-hidden="true">
-                          ${this.knx.localize("group_monitor_time_delta_after")}
-                        </div>
-                        <div class="input-wrapper">
-                          <ha-selector-number
-                            id="delta-after"
-                            .hass=${this.hass}
-                            .value=${this.deltaAfter}
-                            .disabled=${this.disabled}
-                            .label=${this.knx.localize("group_monitor_time_delta_after")}
-                            .selector=${{
-                              number: {
-                                min: 0,
-                                step: 10,
-                                mode: "box",
-                                unit_of_measurement: "ms",
-                              },
-                            }}
-                            @value-changed=${this._handleAfterInput}
-                          ></ha-selector-number>
-                        </div>
-                      </div>
-                    `}
               </div>
             `
           : nothing}
@@ -315,15 +316,6 @@ export class KnxTimeDeltaFilter extends LitElement {
       display: flex;
       flex-direction: column;
       margin-bottom: 8px;
-    }
-
-    .input-label {
-      font-size: 0.8em;
-      font-weight: 500;
-      color: var(--secondary-text-color);
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-      margin-bottom: 4px;
     }
 
     .input-wrapper {

--- a/src/components/data-table/filter/knx-time-delta-filter.ts
+++ b/src/components/data-table/filter/knx-time-delta-filter.ts
@@ -36,9 +36,6 @@ export interface TimeDeltaChangedEvent {
   deltaAfter: number;
 }
 
-/**
- * Event payload for expansion state changes
- */
 @customElement("knx-time-delta-filter")
 export class KnxTimeDeltaFilter extends LitElement {
   @property({ attribute: false, hasChanged: () => false }) public hass!: HomeAssistant;
@@ -239,7 +236,7 @@ export class KnxTimeDeltaFilter extends LitElement {
   // Styles
   // ============================================================================
 
-  static readonly styles = css`
+  static styles = css`
     :host {
       display: flex;
       flex-direction: column;

--- a/src/components/data-table/filter/knx-time-delta-filter.ts
+++ b/src/components/data-table/filter/knx-time-delta-filter.ts
@@ -12,10 +12,12 @@
 import type { TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
+import { mdiFilterVariantRemove } from "@mdi/js";
 
-import "@ha/components/ha-expansion-panel";
-import "@ha/components/ha-textfield";
+import "@ha/components/ha-icon-button";
+import "@ha/components/ha-selector/ha-selector-number";
 import { fireEvent } from "@ha/common/dom/fire_event";
+import type { HomeAssistant } from "@ha/types";
 
 import "../../flex-content-expansion-panel";
 import type { KNX } from "../../../types/knx";
@@ -44,6 +46,8 @@ export interface TimeDeltaExpandedChangedEvent {
 
 @customElement("knx-time-delta-filter")
 export class KnxTimeDeltaFilter extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
   /**
    * KNX integration instance providing localization
    */
@@ -65,6 +69,11 @@ export class KnxTimeDeltaFilter extends LitElement {
   @property({ type: Number, attribute: "delta-after" }) public deltaAfter = 0;
 
   /**
+   * Number of telegrams added by this filter
+   */
+  @property({ type: Number, attribute: "added-count" }) public addedCount = 0;
+
+  /**
    * Whether the filter is disabled (no other filters active)
    */
   @property({ type: Boolean }) public disabled = false;
@@ -78,20 +87,28 @@ export class KnxTimeDeltaFilter extends LitElement {
     fireEvent(this, "expanded-changed", { expanded: this.expanded });
   }
 
-  private _handleBeforeInput(ev: InputEvent): void {
-    const target = ev.target as HTMLInputElement;
-    const value = Math.max(0, Math.floor(Number(target.value) || 0));
+  private _handleBeforeInput(ev: CustomEvent): void {
+    const value = Math.max(0, Math.floor(Number(ev.detail.value) || 0));
     if (value !== this.deltaBefore) {
       this.deltaBefore = value;
       this._fireTimeDeltaChanged();
     }
   }
 
-  private _handleAfterInput(ev: InputEvent): void {
-    const target = ev.target as HTMLInputElement;
-    const value = Math.max(0, Math.floor(Number(target.value) || 0));
+  private _handleAfterInput(ev: CustomEvent): void {
+    const value = Math.max(0, Math.floor(Number(ev.detail.value) || 0));
     if (value !== this.deltaAfter) {
       this.deltaAfter = value;
+      this._fireTimeDeltaChanged();
+    }
+  }
+
+  private _handleClearFiltersButtonClick(ev: MouseEvent): void {
+    ev.stopPropagation();
+    ev.preventDefault();
+    if (this.deltaBefore > 0 || this.deltaAfter > 0) {
+      this.deltaBefore = 0;
+      this.deltaAfter = 0;
       this._fireTimeDeltaChanged();
     }
   }
@@ -120,13 +137,42 @@ export class KnxTimeDeltaFilter extends LitElement {
         <div slot="header" class="header">
           <span class="title">
             ${headerText}
-            ${hasValues && !this.disabled ? html`<div class="badge">●</div>` : nothing}
+            ${hasValues && !this.disabled ? html`<div class="badge">1</div>` : nothing}
           </span>
+          <div class="controls">
+            ${hasValues && !this.disabled
+              ? html`
+                  <ha-icon-button
+                    .path=${mdiFilterVariantRemove}
+                    @click=${this._handleClearFiltersButtonClick}
+                    .title=${this.knx.localize("knx_list_filter_clear")}
+                  ></ha-icon-button>
+                `
+              : nothing}
+          </div>
         </div>
 
         ${this.expanded
           ? html`
               <div class="filter-content">
+                ${hasValues && !this.disabled
+                  ? html`
+                      <div class="summary-item">
+                        <div class="summary-text">
+                          <div class="summary-primary">
+                            <span class="summary-label">
+                              ${this.knx.localize("group_monitor_time_delta_summary", {
+                                before: this.deltaBefore,
+                                after: this.deltaAfter,
+                              })}
+                            </span>
+                            <span class="summary-badge">${this.addedCount}</span>
+                          </div>
+                        </div>
+                      </div>
+                    `
+                  : nothing}
+
                 <p class="description">
                   ${this.knx.localize("group_monitor_time_delta_description")}
                 </p>
@@ -139,40 +185,50 @@ export class KnxTimeDeltaFilter extends LitElement {
                     `
                   : html`
                       <div class="input-row">
-                        <label class="input-label">
+                        <div class="input-label" aria-hidden="true">
                           ${this.knx.localize("group_monitor_time_delta_before")}
-                        </label>
+                        </div>
                         <div class="input-wrapper">
-                          <ha-textfield
-                            type="number"
-                            .value=${this.deltaBefore.toString()}
-                            .placeholder=${this.knx.localize(
-                              "group_monitor_time_delta_placeholder",
-                            )}
-                            min="0"
+                          <ha-selector-number
+                            id="delta-before"
+                            .hass=${this.hass}
+                            .value=${this.deltaBefore}
                             .disabled=${this.disabled}
-                            @change=${this._handleBeforeInput}
-                            suffix="ms"
-                          ></ha-textfield>
+                            .label=${this.knx.localize("group_monitor_time_delta_before")}
+                            .selector=${{
+                              number: {
+                                min: 0,
+                                step: 10,
+                                mode: "box",
+                                unit_of_measurement: "ms",
+                              },
+                            }}
+                            @value-changed=${this._handleBeforeInput}
+                          ></ha-selector-number>
                         </div>
                       </div>
 
                       <div class="input-row">
-                        <label class="input-label">
+                        <div class="input-label" aria-hidden="true">
                           ${this.knx.localize("group_monitor_time_delta_after")}
-                        </label>
+                        </div>
                         <div class="input-wrapper">
-                          <ha-textfield
-                            type="number"
-                            .value=${this.deltaAfter.toString()}
-                            .placeholder=${this.knx.localize(
-                              "group_monitor_time_delta_placeholder",
-                            )}
-                            min="0"
+                          <ha-selector-number
+                            id="delta-after"
+                            .hass=${this.hass}
+                            .value=${this.deltaAfter}
                             .disabled=${this.disabled}
-                            @change=${this._handleAfterInput}
-                            suffix="ms"
-                          ></ha-textfield>
+                            .label=${this.knx.localize("group_monitor_time_delta_after")}
+                            .selector=${{
+                              number: {
+                                min: 0,
+                                step: 10,
+                                mode: "box",
+                                unit_of_measurement: "ms",
+                              },
+                            }}
+                            @value-changed=${this._handleAfterInput}
+                          ></ha-selector-number>
                         </div>
                       </div>
                     `}
@@ -221,8 +277,15 @@ export class KnxTimeDeltaFilter extends LitElement {
       align-items: center;
       justify-content: center;
       margin-left: 8px;
-      font-size: 10px;
-      color: var(--primary-color);
+      min-width: 20px;
+      height: 20px;
+      box-sizing: border-box;
+      border-radius: 50%;
+      font-weight: 500;
+      background-color: var(--primary-color);
+      color: var(--text-primary-color, white);
+      font-size: 12px;
+      padding: 0 4px;
     }
 
     .filter-content {
@@ -269,8 +332,62 @@ export class KnxTimeDeltaFilter extends LitElement {
       gap: 8px;
     }
 
-    ha-textfield {
+    ha-selector-number {
       flex: 1;
+      width: 100%;
+    }
+
+    .controls {
+      display: flex;
+      align-items: center;
+    }
+
+    .summary-item {
+      display: flex;
+      align-items: center;
+      height: 48px;
+      padding: 0 16px;
+      margin: 0 -16px 8px -16px;
+      background-color: var(--mdc-theme-surface-variant, rgba(var(--rgb-primary-color), 0.06));
+    }
+
+    .summary-text {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-width: 0;
+      line-height: normal;
+    }
+
+    .summary-primary {
+      display: flex;
+      align-items: center;
+      width: 100%;
+      gap: 8px;
+    }
+
+    .summary-label {
+      font-weight: 500;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      flex: 1;
+    }
+
+    .summary-badge {
+      display: inline-flex;
+      background-color: rgba(var(--rgb-primary-color), 0.15);
+      color: var(--primary-color);
+      font-weight: 500;
+      font-size: 0.75em;
+      padding: 1px 6px;
+      border-radius: 10px;
+      min-width: 20px;
+      height: 16px;
+      align-items: center;
+      justify-content: center;
+      vertical-align: middle;
+      flex-shrink: 0;
     }
   `;
 }

--- a/src/features/group-monitor/controller/group-monitor-controller-time-delta.test.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller-time-delta.test.ts
@@ -7,6 +7,18 @@ vi.mock("../../../services/websocket.service", () => ({
   getGroupMonitorInfo: vi.fn(),
 }));
 
+vi.mock("../../../tools/knx-logger", () => ({
+  KNXLogger: class {
+    debug = vi.fn();
+
+    info = vi.fn();
+
+    warn = vi.fn();
+
+    error = vi.fn();
+  },
+}));
+
 /**
  * Helper function to create mock telegram data for testing
  */

--- a/src/features/group-monitor/controller/group-monitor-controller-time-delta.test.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller-time-delta.test.ts
@@ -228,8 +228,7 @@ describe("GroupMonitorController - Time-Delta Expansion", () => {
   describe("URL Syncing", () => {
     it("should reset time-delta values when missing from URL even if list filters exist", () => {
       // Setup: existing state in controller
-      (controller as any)._timeDeltaBefore = 100;
-      (controller as any)._timeDeltaAfter = 100;
+      controller.setTimeDelta(100, 100);
 
       // Mock URL with ONLY a list filter, no timedelta params
       const mockSearch = "?source=1.1.1";
@@ -244,8 +243,8 @@ describe("GroupMonitorController - Time-Delta Expansion", () => {
         (controller as any)._setFiltersFromUrl();
 
         // Verification
-        expect((controller as any)._timeDeltaBefore).toBe(0);
-        expect((controller as any)._timeDeltaAfter).toBe(0);
+        expect(controller.timeDeltaBefore).toBe(0);
+        expect(controller.timeDeltaAfter).toBe(0);
         expect(controller.filters.source).toEqual(["1.1.1"]);
       } finally {
         vi.unstubAllGlobals();
@@ -263,8 +262,8 @@ describe("GroupMonitorController - Time-Delta Expansion", () => {
       try {
         (controller as any)._setFiltersFromUrl();
 
-        expect((controller as any)._timeDeltaBefore).toBe(200);
-        expect((controller as any)._timeDeltaAfter).toBe(300);
+        expect(controller.timeDeltaBefore).toBe(200);
+        expect(controller.timeDeltaAfter).toBe(300);
       } finally {
         vi.unstubAllGlobals();
       }

--- a/src/features/group-monitor/controller/group-monitor-controller-time-delta.test.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller-time-delta.test.ts
@@ -224,4 +224,37 @@ describe("GroupMonitorController - Time-Delta Expansion", () => {
       expect(result.map((r) => r.sourceAddress).sort()).toEqual(["1.2.1", "1.2.2", "1.2.3"]);
     });
   });
+
+  describe("Automatic Reset Logic", () => {
+    it("should reset time-delta values when all list filters are removed", async () => {
+      // Setup: List filter + Time Delta
+      controller.setFilterFieldValue("source", ["1.1.1"]);
+      controller.setTimeDelta(100, 100);
+
+      // Verify initial state
+      expect((controller as any)._timeDeltaBefore).toBe(100);
+      expect((controller as any)._timeDeltaAfter).toBe(100);
+
+      // Action: Clear list filter
+      controller.setFilterFieldValue("source", []);
+
+      // Verification: Time delta should be reset
+      expect((controller as any)._timeDeltaBefore).toBe(0);
+      expect((controller as any)._timeDeltaAfter).toBe(0);
+    });
+
+    it("should not reset time-delta values if at least one list filter remains", async () => {
+      // Setup: Multiple list filters + Time Delta
+      controller.setFilterFieldValue("source", ["1.1.1"]);
+      controller.setFilterFieldValue("destination", ["1/1/1"]);
+      controller.setTimeDelta(100, 100);
+
+      // Action: Clear one list filter
+      controller.setFilterFieldValue("source", []);
+
+      // Verification: Time delta should NOT be reset
+      expect((controller as any)._timeDeltaBefore).toBe(100);
+      expect((controller as any)._timeDeltaAfter).toBe(100);
+    });
+  });
 });

--- a/src/features/group-monitor/controller/group-monitor-controller-time-delta.test.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller-time-delta.test.ts
@@ -225,36 +225,49 @@ describe("GroupMonitorController - Time-Delta Expansion", () => {
     });
   });
 
-  describe("Automatic Reset Logic", () => {
-    it("should reset time-delta values when all list filters are removed", async () => {
-      // Setup: List filter + Time Delta
-      controller.setFilterFieldValue("source", ["1.1.1"]);
-      controller.setTimeDelta(100, 100);
+  describe("URL Syncing", () => {
+    it("should reset time-delta values when missing from URL even if list filters exist", () => {
+      // Setup: existing state in controller
+      (controller as any)._timeDeltaBefore = 100;
+      (controller as any)._timeDeltaAfter = 100;
 
-      // Verify initial state
-      expect((controller as any)._timeDeltaBefore).toBe(100);
-      expect((controller as any)._timeDeltaAfter).toBe(100);
+      // Mock URL with ONLY a list filter, no timedelta params
+      const mockSearch = "?source=1.1.1";
+      const originalLocation = window.location;
+      vi.stubGlobal("location", {
+        ...originalLocation,
+        search: mockSearch,
+      });
 
-      // Action: Clear list filter
-      controller.setFilterFieldValue("source", []);
+      try {
+        // Action: restore from URL
+        (controller as any)._setFiltersFromUrl();
 
-      // Verification: Time delta should be reset
-      expect((controller as any)._timeDeltaBefore).toBe(0);
-      expect((controller as any)._timeDeltaAfter).toBe(0);
+        // Verification
+        expect((controller as any)._timeDeltaBefore).toBe(0);
+        expect((controller as any)._timeDeltaAfter).toBe(0);
+        expect(controller.filters.source).toEqual(["1.1.1"]);
+      } finally {
+        vi.unstubAllGlobals();
+      }
     });
 
-    it("should not reset time-delta values if at least one list filter remains", async () => {
-      // Setup: Multiple list filters + Time Delta
-      controller.setFilterFieldValue("source", ["1.1.1"]);
-      controller.setFilterFieldValue("destination", ["1/1/1"]);
-      controller.setTimeDelta(100, 100);
+    it("should restore time-delta values from URL when present", () => {
+      const mockSearch = "?source=1.1.1&timedelta_before=200&timedelta_after=300";
+      const originalLocation = window.location;
+      vi.stubGlobal("location", {
+        ...originalLocation,
+        search: mockSearch,
+      });
 
-      // Action: Clear one list filter
-      controller.setFilterFieldValue("source", []);
+      try {
+        (controller as any)._setFiltersFromUrl();
 
-      // Verification: Time delta should NOT be reset
-      expect((controller as any)._timeDeltaBefore).toBe(100);
-      expect((controller as any)._timeDeltaAfter).toBe(100);
+        expect((controller as any)._timeDeltaBefore).toBe(200);
+        expect((controller as any)._timeDeltaAfter).toBe(300);
+      } finally {
+        vi.unstubAllGlobals();
+      }
     });
   });
 });

--- a/src/features/group-monitor/controller/group-monitor-controller-time-delta.test.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller-time-delta.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from "vitest";
+import { TelegramRow } from "../types/telegram-row";
+import type { TelegramDict } from "../../../types/websocket";
+import { GroupMonitorController } from "./group-monitor-controller";
+
+/**
+ * Helper function to create mock telegram data for testing
+ */
+function createMockTelegram(overrides: Partial<TelegramDict> = {}): TelegramDict {
+  return {
+    timestamp: "2024-01-01T10:00:00.000Z",
+    source: "1.2.3",
+    source_name: "Test Source",
+    destination: "1/2/3",
+    destination_name: "Test Light",
+    telegramtype: "GroupValueWrite",
+    direction: "Outgoing",
+    payload: [1],
+    dpt_main: 1,
+    dpt_sub: 1,
+    dpt_name: "1.001",
+    unit: null,
+    value: "On",
+    ...overrides,
+  };
+}
+
+/**
+ * Helper to create TelegramRow with specific timestamp, source and destination
+ */
+function createTelegramRow(
+  timestamp: string,
+  source = "1.2.3",
+  destination = "1/2/3",
+  telegramtype = "GroupValueWrite",
+  direction = "Outgoing",
+): TelegramRow {
+  const mockData = createMockTelegram({
+    timestamp,
+    source,
+    destination,
+    telegramtype,
+    direction,
+  });
+  return new TelegramRow(mockData);
+}
+
+/**
+ * Test the time-delta expansion logic directly.
+ * We access the private method via casting to any, since
+ * it encapsulates the core algorithm we want to verify.
+ */
+describe("GroupMonitorController - Time-Delta Expansion", () => {
+  // Create a controller instance to test the private method
+  // We need a minimal host mock
+  const mockHost = {
+    addController: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+    removeController: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+    requestUpdate: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+    updateComplete: Promise.resolve(true),
+  };
+
+  const controller = new GroupMonitorController(mockHost as any);
+  const applyTimeDeltaExpansion = (controller as any)._applyTimeDeltaExpansion.bind(controller);
+
+  describe("No delta (passthrough)", () => {
+    it("should return matching telegrams unchanged when both deltas are 0", () => {
+      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
+      const t2 = createTelegramRow("2024-01-01T10:00:01.000Z", "1.2.2", "1/2/2");
+      const t3 = createTelegramRow("2024-01-01T10:00:02.000Z", "1.2.3", "1/2/3");
+
+      const allTelegrams = [t1, t2, t3];
+      const matchingTelegrams = [t2];
+
+      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 0, 0);
+      expect(result).toEqual([t2]);
+    });
+
+    it("should return matching telegrams unchanged when matching is empty", () => {
+      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
+      const result = applyTimeDeltaExpansion([], [t1], 500, 500);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("Before delta only", () => {
+    it("should include telegrams within the before window", () => {
+      // t1 at 10:00:00.000, t2 at 10:00:00.500, t3 at 10:00:01.000
+      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
+      const t2 = createTelegramRow("2024-01-01T10:00:00.500Z", "1.2.2", "1/2/2");
+      const t3 = createTelegramRow("2024-01-01T10:00:01.000Z", "1.2.3", "1/2/3");
+
+      const allTelegrams = [t1, t2, t3];
+      const matchingTelegrams = [t3]; // Only t3 matches filters
+
+      // 600ms before t3 should include t2 (500ms before) but not t1 (1000ms before)
+      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 600, 0);
+      expect(result).toHaveLength(2);
+      expect(result).toContain(t2);
+      expect(result).toContain(t3);
+    });
+
+    it("should not include telegrams outside the before window", () => {
+      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
+      const t2 = createTelegramRow("2024-01-01T10:00:02.000Z", "1.2.2", "1/2/2");
+
+      const allTelegrams = [t1, t2];
+      const matchingTelegrams = [t2];
+
+      // 500ms before t2 should NOT include t1 (2000ms before)
+      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 500, 0);
+      expect(result).toHaveLength(1);
+      expect(result).toContain(t2);
+    });
+  });
+
+  describe("After delta only", () => {
+    it("should include telegrams within the after window", () => {
+      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
+      const t2 = createTelegramRow("2024-01-01T10:00:00.300Z", "1.2.2", "1/2/2");
+      const t3 = createTelegramRow("2024-01-01T10:00:02.000Z", "1.2.3", "1/2/3");
+
+      const allTelegrams = [t1, t2, t3];
+      const matchingTelegrams = [t1]; // Only t1 matches filters
+
+      // 500ms after t1 should include t2 (300ms after) but not t3 (2000ms after)
+      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 0, 500);
+      expect(result).toHaveLength(2);
+      expect(result).toContain(t1);
+      expect(result).toContain(t2);
+    });
+  });
+
+  describe("Both before and after deltas", () => {
+    it("should include telegrams in the full window around matching telegrams", () => {
+      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
+      const t2 = createTelegramRow("2024-01-01T10:00:00.500Z", "1.2.2", "1/2/2");
+      const t3 = createTelegramRow("2024-01-01T10:00:01.000Z", "1.2.3", "1/2/3"); // Match
+      const t4 = createTelegramRow("2024-01-01T10:00:01.400Z", "1.2.4", "1/2/4");
+      const t5 = createTelegramRow("2024-01-01T10:00:03.000Z", "1.2.5", "1/2/5");
+
+      const allTelegrams = [t1, t2, t3, t4, t5];
+      const matchingTelegrams = [t3];
+
+      // 600ms before and 500ms after t3 (10:00:01.000)
+      // Window: [10:00:00.400, 10:00:01.500]
+      // t2 at 10:00:00.500 → included (within before window)
+      // t3 at 10:00:01.000 → included (matching)
+      // t4 at 10:00:01.400 → included (within after window)
+      // t1 at 10:00:00.000 → excluded (1000ms before, outside 600ms window)
+      // t5 at 10:00:03.000 → excluded (2000ms after, outside 500ms window)
+      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 600, 500);
+      expect(result).toHaveLength(3);
+      expect(result).toContain(t2);
+      expect(result).toContain(t3);
+      expect(result).toContain(t4);
+      expect(result).not.toContain(t1);
+      expect(result).not.toContain(t5);
+    });
+  });
+
+  describe("Multiple matching telegrams with overlapping windows", () => {
+    it("should deduplicate when windows overlap", () => {
+      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1"); // Match
+      const t2 = createTelegramRow("2024-01-01T10:00:00.300Z", "1.2.2", "1/2/2"); // Context
+      const t3 = createTelegramRow("2024-01-01T10:00:00.600Z", "1.2.3", "1/2/3"); // Match
+
+      const allTelegrams = [t1, t2, t3];
+      const matchingTelegrams = [t1, t3];
+
+      // 400ms after t1 includes t2; 400ms before t3 includes t2
+      // t2 should only appear once in the result
+      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 400, 400);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toBe(t1);
+      expect(result[1]).toBe(t2);
+      expect(result[2]).toBe(t3);
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should return all telegrams when window covers entire buffer", () => {
+      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
+      const t2 = createTelegramRow("2024-01-01T10:00:01.000Z", "1.2.2", "1/2/2");
+      const t3 = createTelegramRow("2024-01-01T10:00:02.000Z", "1.2.3", "1/2/3");
+
+      const allTelegrams = [t1, t2, t3];
+      const matchingTelegrams = [t2];
+
+      // 5000ms before and 5000ms after covers everything
+      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 5000, 5000);
+      expect(result).toHaveLength(3);
+    });
+
+    it("should preserve chronological order", () => {
+      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
+      const t2 = createTelegramRow("2024-01-01T10:00:00.100Z", "1.2.2", "1/2/2");
+      const t3 = createTelegramRow("2024-01-01T10:00:00.200Z", "1.2.3", "1/2/3");
+      const t4 = createTelegramRow("2024-01-01T10:00:00.300Z", "1.2.4", "1/2/4");
+
+      const allTelegrams = [t1, t2, t3, t4];
+      const matchingTelegrams = [t3]; // Match t3
+
+      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 150, 150);
+      // Window: [10:00:00.050, 10:00:00.350]
+      // Includes: t2 (100ms), t3 (200ms), t4 (300ms)
+      expect(result).toHaveLength(3);
+      expect(result[0]).toBe(t2);
+      expect(result[1]).toBe(t3);
+      expect(result[2]).toBe(t4);
+    });
+
+    it("should handle when all telegrams already match (skip expansion)", () => {
+      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
+      const t2 = createTelegramRow("2024-01-01T10:00:01.000Z", "1.2.2", "1/2/2");
+
+      const allTelegrams = [t1, t2];
+      const matchingTelegrams = [t1, t2]; // All match
+
+      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 500, 500);
+      expect(result).toEqual(matchingTelegrams);
+    });
+
+    it("should handle exact boundary inclusion (timestamp equals window edge)", () => {
+      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
+      const t2 = createTelegramRow("2024-01-01T10:00:00.500Z", "1.2.2", "1/2/2"); // Match
+      const t3 = createTelegramRow("2024-01-01T10:00:01.000Z", "1.2.3", "1/2/3");
+
+      const allTelegrams = [t1, t2, t3];
+      const matchingTelegrams = [t2];
+
+      // Exactly 500ms before and 500ms after
+      // t1 is exactly at the boundary (500ms before t2) → should be included
+      // t3 is exactly at the boundary (500ms after t2) → should be included
+      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 500, 500);
+      expect(result).toHaveLength(3);
+      expect(result).toContain(t1);
+      expect(result).toContain(t2);
+      expect(result).toContain(t3);
+    });
+  });
+});

--- a/src/features/group-monitor/controller/group-monitor-controller-time-delta.test.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller-time-delta.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { TelegramRow } from "../types/telegram-row";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { TelegramDict } from "../../../types/websocket";
 import { GroupMonitorController } from "./group-monitor-controller";
+import { getGroupMonitorInfo } from "../../../services/websocket.service";
+
+vi.mock("../../../services/websocket.service", () => ({
+  getGroupMonitorInfo: vi.fn(),
+}));
 
 /**
  * Helper function to create mock telegram data for testing
@@ -25,218 +29,199 @@ function createMockTelegram(overrides: Partial<TelegramDict> = {}): TelegramDict
   };
 }
 
-/**
- * Helper to create TelegramRow with specific timestamp, source and destination
- */
-function createTelegramRow(
-  timestamp: string,
-  source = "1.2.3",
-  destination = "1/2/3",
-  telegramtype = "GroupValueWrite",
-  direction = "Outgoing",
-): TelegramRow {
-  const mockData = createMockTelegram({
-    timestamp,
-    source,
-    destination,
-    telegramtype,
-    direction,
-  });
-  return new TelegramRow(mockData);
-}
-
-/**
- * Test the time-delta expansion logic directly.
- * We access the private method via casting to any, since
- * it encapsulates the core algorithm we want to verify.
- */
 describe("GroupMonitorController - Time-Delta Expansion", () => {
-  // Create a controller instance to test the private method
-  // We need a minimal host mock
-  const mockHost = {
-    addController: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
-    removeController: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
-    requestUpdate: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
-    updateComplete: Promise.resolve(true),
+  let controller: GroupMonitorController;
+
+  beforeEach(() => {
+    const mockHost = {
+      addController: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+      removeController: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+      requestUpdate: () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
+      updateComplete: Promise.resolve(true),
+    };
+    controller = new GroupMonitorController(mockHost as any);
+  });
+
+  const injectTelegrams = async (telegrams: TelegramDict[]) => {
+    vi.mocked(getGroupMonitorInfo).mockResolvedValueOnce({
+      project_loaded: true,
+      recent_telegrams: telegrams,
+    } as any);
+    await controller.reload({} as any);
   };
 
-  const controller = new GroupMonitorController(mockHost as any);
-  const applyTimeDeltaExpansion = (controller as any)._applyTimeDeltaExpansion.bind(controller);
+  const getFiltered = () => controller.getFilteredTelegramsAndDistinctValues().filteredTelegrams;
+  const getFilteredResult = () => controller.getFilteredTelegramsAndDistinctValues();
 
   describe("No delta (passthrough)", () => {
-    it("should return matching telegrams unchanged when both deltas are 0", () => {
-      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
-      const t2 = createTelegramRow("2024-01-01T10:00:01.000Z", "1.2.2", "1/2/2");
-      const t3 = createTelegramRow("2024-01-01T10:00:02.000Z", "1.2.3", "1/2/3");
+    it("should return matching telegrams unchanged when both deltas are 0", async () => {
+      await injectTelegrams([
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.000Z", source: "1.2.1" }),
+        createMockTelegram({ timestamp: "2024-01-01T10:00:01.000Z", source: "1.2.2" }),
+        createMockTelegram({ timestamp: "2024-01-01T10:00:02.000Z", source: "1.2.3" }),
+      ]);
 
-      const allTelegrams = [t1, t2, t3];
-      const matchingTelegrams = [t2];
+      controller.setFilterFieldValue("source", ["1.2.2"]);
+      controller.setTimeDelta(0, 0);
 
-      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 0, 0);
-      expect(result).toEqual([t2]);
+      const result = getFiltered();
+      expect(result).toHaveLength(1);
+      expect(result[0].sourceAddress).toBe("1.2.2");
     });
 
-    it("should return matching telegrams unchanged when matching is empty", () => {
-      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
-      const result = applyTimeDeltaExpansion([], [t1], 500, 500);
+    it("should return empty array when matching is empty", async () => {
+      await injectTelegrams([
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.000Z", source: "1.2.1" }),
+      ]);
+
+      controller.setFilterFieldValue("source", ["9.9.9"]);
+      controller.setTimeDelta(500, 500);
+
+      const result = getFiltered();
       expect(result).toEqual([]);
     });
   });
 
   describe("Before delta only", () => {
-    it("should include telegrams within the before window", () => {
-      // t1 at 10:00:00.000, t2 at 10:00:00.500, t3 at 10:00:01.000
-      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
-      const t2 = createTelegramRow("2024-01-01T10:00:00.500Z", "1.2.2", "1/2/2");
-      const t3 = createTelegramRow("2024-01-01T10:00:01.000Z", "1.2.3", "1/2/3");
+    it("should include telegrams within the before window", async () => {
+      await injectTelegrams([
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.000Z", source: "1.2.1" }), // t1
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.500Z", source: "1.2.2" }), // t2
+        createMockTelegram({ timestamp: "2024-01-01T10:00:01.000Z", source: "1.2.3" }), // t3
+      ]);
 
-      const allTelegrams = [t1, t2, t3];
-      const matchingTelegrams = [t3]; // Only t3 matches filters
-
+      // Only match t3
+      controller.setFilterFieldValue("source", ["1.2.3"]);
       // 600ms before t3 should include t2 (500ms before) but not t1 (1000ms before)
-      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 600, 0);
-      expect(result).toHaveLength(2);
-      expect(result).toContain(t2);
-      expect(result).toContain(t3);
+      controller.setTimeDelta(600, 0);
+
+      const result = getFilteredResult();
+      const filtered = result.filteredTelegrams;
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map((r) => r.sourceAddress).sort()).toEqual(["1.2.2", "1.2.3"]);
+      expect(result.timeDeltaAddedCount).toBe(1);
     });
 
-    it("should not include telegrams outside the before window", () => {
-      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
-      const t2 = createTelegramRow("2024-01-01T10:00:02.000Z", "1.2.2", "1/2/2");
+    it("should not include telegrams outside the before window", async () => {
+      await injectTelegrams([
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.000Z", source: "1.2.1" }),
+        createMockTelegram({ timestamp: "2024-01-01T10:00:02.000Z", source: "1.2.2" }),
+      ]);
 
-      const allTelegrams = [t1, t2];
-      const matchingTelegrams = [t2];
-
+      controller.setFilterFieldValue("source", ["1.2.2"]);
       // 500ms before t2 should NOT include t1 (2000ms before)
-      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 500, 0);
+      controller.setTimeDelta(500, 0);
+
+      const result = getFiltered();
       expect(result).toHaveLength(1);
-      expect(result).toContain(t2);
+      expect(result[0].sourceAddress).toBe("1.2.2");
     });
   });
 
   describe("After delta only", () => {
-    it("should include telegrams within the after window", () => {
-      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
-      const t2 = createTelegramRow("2024-01-01T10:00:00.300Z", "1.2.2", "1/2/2");
-      const t3 = createTelegramRow("2024-01-01T10:00:02.000Z", "1.2.3", "1/2/3");
+    it("should include telegrams within the after window", async () => {
+      await injectTelegrams([
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.000Z", source: "1.2.1" }), // t1
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.300Z", source: "1.2.2" }), // t2
+        createMockTelegram({ timestamp: "2024-01-01T10:00:02.000Z", source: "1.2.3" }), // t3
+      ]);
 
-      const allTelegrams = [t1, t2, t3];
-      const matchingTelegrams = [t1]; // Only t1 matches filters
-
+      controller.setFilterFieldValue("source", ["1.2.1"]);
       // 500ms after t1 should include t2 (300ms after) but not t3 (2000ms after)
-      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 0, 500);
+      controller.setTimeDelta(0, 500);
+
+      const result = getFiltered();
       expect(result).toHaveLength(2);
-      expect(result).toContain(t1);
-      expect(result).toContain(t2);
+      expect(result.map((r) => r.sourceAddress).sort()).toEqual(["1.2.1", "1.2.2"]);
     });
   });
 
   describe("Both before and after deltas", () => {
-    it("should include telegrams in the full window around matching telegrams", () => {
-      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
-      const t2 = createTelegramRow("2024-01-01T10:00:00.500Z", "1.2.2", "1/2/2");
-      const t3 = createTelegramRow("2024-01-01T10:00:01.000Z", "1.2.3", "1/2/3"); // Match
-      const t4 = createTelegramRow("2024-01-01T10:00:01.400Z", "1.2.4", "1/2/4");
-      const t5 = createTelegramRow("2024-01-01T10:00:03.000Z", "1.2.5", "1/2/5");
+    it("should include telegrams in the full window around matching telegrams", async () => {
+      await injectTelegrams([
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.000Z", source: "1.2.1" }), // t1 (ex)
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.500Z", source: "1.2.2" }), // t2 (inc)
+        createMockTelegram({ timestamp: "2024-01-01T10:00:01.000Z", source: "1.2.3" }), // t3 (match)
+        createMockTelegram({ timestamp: "2024-01-01T10:00:01.400Z", source: "1.2.4" }), // t4 (inc)
+        createMockTelegram({ timestamp: "2024-01-01T10:00:03.000Z", source: "1.2.5" }), // t5 (ex)
+      ]);
 
-      const allTelegrams = [t1, t2, t3, t4, t5];
-      const matchingTelegrams = [t3];
+      controller.setFilterFieldValue("source", ["1.2.3"]);
+      controller.setTimeDelta(600, 500);
 
-      // 600ms before and 500ms after t3 (10:00:01.000)
-      // Window: [10:00:00.400, 10:00:01.500]
-      // t2 at 10:00:00.500 → included (within before window)
-      // t3 at 10:00:01.000 → included (matching)
-      // t4 at 10:00:01.400 → included (within after window)
-      // t1 at 10:00:00.000 → excluded (1000ms before, outside 600ms window)
-      // t5 at 10:00:03.000 → excluded (2000ms after, outside 500ms window)
-      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 600, 500);
-      expect(result).toHaveLength(3);
-      expect(result).toContain(t2);
-      expect(result).toContain(t3);
-      expect(result).toContain(t4);
-      expect(result).not.toContain(t1);
-      expect(result).not.toContain(t5);
+      const result = getFilteredResult();
+      const filtered = result.filteredTelegrams;
+      expect(filtered).toHaveLength(3);
+      expect(filtered.map((r) => r.sourceAddress).sort()).toEqual(["1.2.2", "1.2.3", "1.2.4"]);
+      expect(result.timeDeltaAddedCount).toBe(2);
     });
   });
 
   describe("Multiple matching telegrams with overlapping windows", () => {
-    it("should deduplicate when windows overlap", () => {
-      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1"); // Match
-      const t2 = createTelegramRow("2024-01-01T10:00:00.300Z", "1.2.2", "1/2/2"); // Context
-      const t3 = createTelegramRow("2024-01-01T10:00:00.600Z", "1.2.3", "1/2/3"); // Match
+    it("should deduplicate when windows overlap", async () => {
+      await injectTelegrams([
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.000Z", source: "1.2.1" }), // Match
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.300Z", source: "1.2.2" }), // Context
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.600Z", source: "1.2.3" }), // Match
+      ]);
 
-      const allTelegrams = [t1, t2, t3];
-      const matchingTelegrams = [t1, t3];
+      controller.setFilterFieldValue("source", ["1.2.1", "1.2.3"]);
+      controller.setTimeDelta(400, 400);
 
-      // 400ms after t1 includes t2; 400ms before t3 includes t2
-      // t2 should only appear once in the result
-      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 400, 400);
+      const result = getFiltered();
       expect(result).toHaveLength(3);
-      expect(result[0]).toBe(t1);
-      expect(result[1]).toBe(t2);
-      expect(result[2]).toBe(t3);
+      expect(result.map((r) => r.sourceAddress).sort()).toEqual(["1.2.1", "1.2.2", "1.2.3"]);
     });
   });
 
   describe("Edge cases", () => {
-    it("should return all telegrams when window covers entire buffer", () => {
-      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
-      const t2 = createTelegramRow("2024-01-01T10:00:01.000Z", "1.2.2", "1/2/2");
-      const t3 = createTelegramRow("2024-01-01T10:00:02.000Z", "1.2.3", "1/2/3");
+    it("should return all telegrams when window covers entire buffer", async () => {
+      await injectTelegrams([
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.000Z", source: "1.2.1" }),
+        createMockTelegram({ timestamp: "2024-01-01T10:00:01.000Z", source: "1.2.2" }),
+        createMockTelegram({ timestamp: "2024-01-01T10:00:02.000Z", source: "1.2.3" }),
+      ]);
 
-      const allTelegrams = [t1, t2, t3];
-      const matchingTelegrams = [t2];
+      controller.setFilterFieldValue("source", ["1.2.2"]);
+      controller.setTimeDelta(5000, 5000);
 
-      // 5000ms before and 5000ms after covers everything
-      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 5000, 5000);
+      const result = getFiltered();
       expect(result).toHaveLength(3);
     });
 
-    it("should preserve chronological order", () => {
-      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
-      const t2 = createTelegramRow("2024-01-01T10:00:00.100Z", "1.2.2", "1/2/2");
-      const t3 = createTelegramRow("2024-01-01T10:00:00.200Z", "1.2.3", "1/2/3");
-      const t4 = createTelegramRow("2024-01-01T10:00:00.300Z", "1.2.4", "1/2/4");
+    it("should preserve chronological order when not sorting explicitly", async () => {
+      controller.sortColumn = undefined;
 
-      const allTelegrams = [t1, t2, t3, t4];
-      const matchingTelegrams = [t3]; // Match t3
+      await injectTelegrams([
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.000Z", source: "1.2.1" }),
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.100Z", source: "1.2.2" }),
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.200Z", source: "1.2.3" }),
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.300Z", source: "1.2.4" }),
+      ]);
 
-      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 150, 150);
-      // Window: [10:00:00.050, 10:00:00.350]
-      // Includes: t2 (100ms), t3 (200ms), t4 (300ms)
+      controller.setFilterFieldValue("source", ["1.2.3"]);
+      controller.setTimeDelta(150, 150);
+
+      const result = getFiltered();
       expect(result).toHaveLength(3);
-      expect(result[0]).toBe(t2);
-      expect(result[1]).toBe(t3);
-      expect(result[2]).toBe(t4);
+      expect(result[0].sourceAddress).toBe("1.2.2");
+      expect(result[1].sourceAddress).toBe("1.2.3");
+      expect(result[2].sourceAddress).toBe("1.2.4");
     });
 
-    it("should handle when all telegrams already match (skip expansion)", () => {
-      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
-      const t2 = createTelegramRow("2024-01-01T10:00:01.000Z", "1.2.2", "1/2/2");
+    it("should handle exact boundary inclusion (timestamp equals window edge)", async () => {
+      await injectTelegrams([
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.000Z", source: "1.2.1" }), // Edge
+        createMockTelegram({ timestamp: "2024-01-01T10:00:00.500Z", source: "1.2.2" }), // Match
+        createMockTelegram({ timestamp: "2024-01-01T10:00:01.000Z", source: "1.2.3" }), // Edge
+      ]);
 
-      const allTelegrams = [t1, t2];
-      const matchingTelegrams = [t1, t2]; // All match
+      controller.setFilterFieldValue("source", ["1.2.2"]);
+      controller.setTimeDelta(500, 500);
 
-      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 500, 500);
-      expect(result).toEqual(matchingTelegrams);
-    });
-
-    it("should handle exact boundary inclusion (timestamp equals window edge)", () => {
-      const t1 = createTelegramRow("2024-01-01T10:00:00.000Z", "1.2.1", "1/2/1");
-      const t2 = createTelegramRow("2024-01-01T10:00:00.500Z", "1.2.2", "1/2/2"); // Match
-      const t3 = createTelegramRow("2024-01-01T10:00:01.000Z", "1.2.3", "1/2/3");
-
-      const allTelegrams = [t1, t2, t3];
-      const matchingTelegrams = [t2];
-
-      // Exactly 500ms before and 500ms after
-      // t1 is exactly at the boundary (500ms before t2) → should be included
-      // t3 is exactly at the boundary (500ms after t2) → should be included
-      const result = applyTimeDeltaExpansion(matchingTelegrams, allTelegrams, 500, 500);
+      const result = getFiltered();
       expect(result).toHaveLength(3);
-      expect(result).toContain(t1);
-      expect(result).toContain(t2);
-      expect(result).toContain(t3);
+      expect(result.map((r) => r.sourceAddress).sort()).toEqual(["1.2.1", "1.2.2", "1.2.3"]);
     });
   });
 });

--- a/src/features/group-monitor/controller/group-monitor-controller.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller.ts
@@ -44,6 +44,7 @@ export type DistinctValues = Record<FilterField, Record<string, DistinctValueInf
 export interface FilteredTelegramsResult {
   filteredTelegrams: TelegramRow[];
   distinctValues: DistinctValues;
+  timeDeltaAddedCount?: number;
 }
 
 /**
@@ -222,17 +223,6 @@ export class GroupMonitorController implements ReactiveController {
   }
 
   /**
-   * Whether the time-delta filter is active
-   * Only active when at least one list-based filter is set AND a delta > 0
-   */
-  public get isTimeDeltaActive(): boolean {
-    const hasListFilters = Object.values(this._filters).some(
-      (f) => Array.isArray(f) && f.length > 0,
-    );
-    return hasListFilters && (this._timeDeltaBefore > 0 || this._timeDeltaAfter > 0);
-  }
-
-  /**
    * Whether any list-based filters are active
    * Used by the UI to decide whether to disable the time-delta inputs
    */
@@ -299,6 +289,8 @@ export class GroupMonitorController implements ReactiveController {
         timeDeltaBefore || 0,
         timeDeltaAfter || 0,
       );
+
+      const timeDeltaAddedCount = filteredTelegrams.length - matchingTelegrams.length;
 
       // Sort telegrams if a sort column and direction are specified
       if (sortColumn && sortDirection) {
@@ -407,6 +399,7 @@ export class GroupMonitorController implements ReactiveController {
       return {
         filteredTelegrams,
         distinctValues: distinctValuesWithFilteredCounts,
+        timeDeltaAddedCount,
       };
     },
   );
@@ -447,6 +440,14 @@ export class GroupMonitorController implements ReactiveController {
       this._filters = { ...this._filters, [field]: [...currentFilters, value] };
     }
 
+    if (!this.hasActiveListFilters) {
+      if (this._timeDeltaBefore > 0 || this._timeDeltaAfter > 0) {
+        this._timeDeltaBefore = 0;
+        this._timeDeltaAfter = 0;
+        this._bufferVersion++;
+      }
+    }
+
     this._updateUrlFromFilters(route);
     this._cleanupUnusedFilterValues();
 
@@ -458,6 +459,15 @@ export class GroupMonitorController implements ReactiveController {
    */
   public setFilterFieldValue(field: string, value: string[], route?: Route): void {
     this._filters = { ...this._filters, [field]: value };
+
+    if (!this.hasActiveListFilters) {
+      if (this._timeDeltaBefore > 0 || this._timeDeltaAfter > 0) {
+        this._timeDeltaBefore = 0;
+        this._timeDeltaAfter = 0;
+        this._bufferVersion++;
+      }
+    }
+
     this._updateUrlFromFilters(route);
     this._cleanupUnusedFilterValues();
 
@@ -481,8 +491,15 @@ export class GroupMonitorController implements ReactiveController {
    * Updates time-delta values and persists to URL
    */
   public setTimeDelta(before: number, after: number, route?: Route): void {
-    this._timeDeltaBefore = Math.max(0, Math.floor(before));
-    this._timeDeltaAfter = Math.max(0, Math.floor(after));
+    const newBefore = Math.max(0, Math.floor(before));
+    const newAfter = Math.max(0, Math.floor(after));
+
+    if (this._timeDeltaBefore === newBefore && this._timeDeltaAfter === newAfter) {
+      return;
+    }
+
+    this._timeDeltaBefore = newBefore;
+    this._timeDeltaAfter = newAfter;
     this._bufferVersion++;
     this._updateUrlFromFilters(route);
     this.host.requestUpdate();
@@ -918,12 +935,13 @@ export class GroupMonitorController implements ReactiveController {
       }
     });
 
-    // Persist time-delta values in URL
-    if (this._timeDeltaBefore > 0) {
-      params.set("timedelta_before", this._timeDeltaBefore.toString());
-    }
-    if (this._timeDeltaAfter > 0) {
-      params.set("timedelta_after", this._timeDeltaAfter.toString());
+    if (this.hasActiveListFilters) {
+      if (this._timeDeltaBefore > 0) {
+        params.set("timedelta_before", this._timeDeltaBefore.toString());
+      }
+      if (this._timeDeltaAfter > 0) {
+        params.set("timedelta_after", this._timeDeltaAfter.toString());
+      }
     }
 
     const newPath = params.toString()
@@ -945,16 +963,18 @@ export class GroupMonitorController implements ReactiveController {
     const timeDeltaBefore = searchParams.get("timedelta_before");
     const timeDeltaAfter = searchParams.get("timedelta_after");
 
-    // Restore time-delta values from URL
+    if (!source && !destination && !direction && !telegramtype) {
+      this._timeDeltaBefore = 0;
+      this._timeDeltaAfter = 0;
+      return;
+    }
+
+    // Restore time-delta values from URL only if list filters exist
     if (timeDeltaBefore) {
       this._timeDeltaBefore = Math.max(0, Math.floor(Number(timeDeltaBefore) || 0));
     }
     if (timeDeltaAfter) {
       this._timeDeltaAfter = Math.max(0, Math.floor(Number(timeDeltaAfter) || 0));
-    }
-
-    if (!source && !destination && !direction && !telegramtype) {
-      return;
     }
 
     this._filters = {

--- a/src/features/group-monitor/controller/group-monitor-controller.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller.ts
@@ -44,7 +44,7 @@ export type DistinctValues = Record<FilterField, Record<string, DistinctValueInf
 export interface FilteredTelegramsResult {
   filteredTelegrams: TelegramRow[];
   distinctValues: DistinctValues;
-  timeDeltaAddedCount?: number;
+  timeDeltaAddedCount: number;
 }
 
 /**
@@ -206,20 +206,8 @@ export class GroupMonitorController implements ReactiveController {
     return this._timeDeltaBefore;
   }
 
-  public set timeDeltaBefore(value: number) {
-    this._timeDeltaBefore = Math.max(0, Math.floor(value));
-    this._bufferVersion++;
-    this.host.requestUpdate();
-  }
-
   public get timeDeltaAfter(): number {
     return this._timeDeltaAfter;
-  }
-
-  public set timeDeltaAfter(value: number) {
-    this._timeDeltaAfter = Math.max(0, Math.floor(value));
-    this._bufferVersion++;
-    this.host.requestUpdate();
   }
 
   /**
@@ -963,13 +951,11 @@ export class GroupMonitorController implements ReactiveController {
       return;
     }
 
-    // Restore time-delta values from URL only if list filters exist
-    this._timeDeltaBefore = timeDeltaBefore
-      ? Math.max(0, Math.floor(Number(timeDeltaBefore) || 0))
-      : 0;
-    this._timeDeltaAfter = timeDeltaAfter
-      ? Math.max(0, Math.floor(Number(timeDeltaAfter) || 0))
-      : 0;
+    // Restore time-delta values from URL when list filters exist.
+    // Missing or invalid query params must reset to 0 so the URL remains
+    // the single source of truth for the controller state.
+    this._timeDeltaBefore = Math.max(0, Math.floor(Number(timeDeltaBefore) || 0));
+    this._timeDeltaAfter = Math.max(0, Math.floor(Number(timeDeltaAfter) || 0));
 
     this._filters = {
       source: source ? source.split(",") : [],

--- a/src/features/group-monitor/controller/group-monitor-controller.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller.ts
@@ -618,23 +618,21 @@ export class GroupMonitorController implements ReactiveController {
       return matchingTelegrams;
     }
 
-    // Collect indices into allTelegrams that should be included
-    const includedIndices = new Set<number>();
-
-    // Pre-extract timestamps as milliseconds for binary search
-    const timestamps = allTelegrams.map((t) => t.timestamp.getTime());
+    const result: TelegramRow[] = [];
+    let lastIncludedIdx = -1;
 
     for (const match of matchingTelegrams) {
       const matchTime = match.timestamp.getTime();
       const windowStart = matchTime - deltaBefore;
       const windowEnd = matchTime + deltaAfter;
 
-      // Binary search for lower bound (first telegram >= windowStart)
-      let lo = 0;
-      let hi = timestamps.length;
+      // Binary search for startIdx (first telegram >= windowStart)
+      // Since windowStart is monotonically increasing, we can start from the previous end
+      let lo = Math.max(0, lastIncludedIdx + 1);
+      let hi = allTelegrams.length;
       while (lo < hi) {
         const mid = Math.floor((lo + hi) / 2);
-        if (timestamps[mid] < windowStart) {
+        if (allTelegrams[mid].timestamp.getTime() < windowStart) {
           lo = mid + 1;
         } else {
           hi = mid;
@@ -642,12 +640,12 @@ export class GroupMonitorController implements ReactiveController {
       }
       const startIdx = lo;
 
-      // Binary search for upper bound (first telegram > windowEnd)
+      // Binary search for endIdx (first telegram > windowEnd)
       lo = startIdx;
-      hi = timestamps.length;
+      hi = allTelegrams.length;
       while (lo < hi) {
         const mid = Math.floor((lo + hi) / 2);
-        if (timestamps[mid] <= windowEnd) {
+        if (allTelegrams[mid].timestamp.getTime() <= windowEnd) {
           lo = mid + 1;
         } else {
           hi = mid;
@@ -655,17 +653,12 @@ export class GroupMonitorController implements ReactiveController {
       }
       const endIdx = lo;
 
-      // Mark all telegrams in the window
-      for (let i = startIdx; i < endIdx; i++) {
-        includedIndices.add(i);
+      // Add telegrams that haven't been added yet (merging overlapping windows)
+      const actualStart = Math.max(startIdx, lastIncludedIdx + 1);
+      for (let i = actualStart; i < endIdx; i++) {
+        result.push(allTelegrams[i]);
       }
-    }
-
-    // Build result preserving original order from allTelegrams
-    // Include: matching telegrams + context telegrams within windows
-    const result: TelegramRow[] = [];
-    for (const idx of Array.from(includedIndices).sort((a, b) => a - b)) {
-      result.push(allTelegrams[idx]);
+      lastIncludedIdx = Math.max(lastIncludedIdx, endIdx - 1);
     }
 
     return result;
@@ -971,12 +964,12 @@ export class GroupMonitorController implements ReactiveController {
     }
 
     // Restore time-delta values from URL only if list filters exist
-    if (timeDeltaBefore) {
-      this._timeDeltaBefore = Math.max(0, Math.floor(Number(timeDeltaBefore) || 0));
-    }
-    if (timeDeltaAfter) {
-      this._timeDeltaAfter = Math.max(0, Math.floor(Number(timeDeltaAfter) || 0));
-    }
+    this._timeDeltaBefore = timeDeltaBefore
+      ? Math.max(0, Math.floor(Number(timeDeltaBefore) || 0))
+      : 0;
+    this._timeDeltaAfter = timeDeltaAfter
+      ? Math.max(0, Math.floor(Number(timeDeltaAfter) || 0))
+      : 0;
 
     this._filters = {
       source: source ? source.split(",") : [],

--- a/src/features/group-monitor/controller/group-monitor-controller.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller.ts
@@ -440,13 +440,7 @@ export class GroupMonitorController implements ReactiveController {
       this._filters = { ...this._filters, [field]: [...currentFilters, value] };
     }
 
-    if (!this.hasActiveListFilters) {
-      if (this._timeDeltaBefore > 0 || this._timeDeltaAfter > 0) {
-        this._timeDeltaBefore = 0;
-        this._timeDeltaAfter = 0;
-        this._bufferVersion++;
-      }
-    }
+    this._resetTimeDeltaIfNoListFilters();
 
     this._updateUrlFromFilters(route);
     this._cleanupUnusedFilterValues();
@@ -460,13 +454,7 @@ export class GroupMonitorController implements ReactiveController {
   public setFilterFieldValue(field: string, value: string[], route?: Route): void {
     this._filters = { ...this._filters, [field]: value };
 
-    if (!this.hasActiveListFilters) {
-      if (this._timeDeltaBefore > 0 || this._timeDeltaAfter > 0) {
-        this._timeDeltaBefore = 0;
-        this._timeDeltaAfter = 0;
-        this._bufferVersion++;
-      }
-    }
+    this._resetTimeDeltaIfNoListFilters();
 
     this._updateUrlFromFilters(route);
     this._cleanupUnusedFilterValues();
@@ -823,6 +811,19 @@ export class GroupMonitorController implements ReactiveController {
 
     // Increment buffer version to invalidate memoization cache
     this._bufferVersion++;
+  }
+
+  /**
+   * Resets time-delta values to 0 if no list filters are active
+   */
+  private _resetTimeDeltaIfNoListFilters(): void {
+    if (!this.hasActiveListFilters) {
+      if (this._timeDeltaBefore > 0 || this._timeDeltaAfter > 0) {
+        this._timeDeltaBefore = 0;
+        this._timeDeltaAfter = 0;
+        this._bufferVersion++;
+      }
+    }
   }
 
   // ============================================================================

--- a/src/features/group-monitor/controller/group-monitor-controller.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller.ts
@@ -86,6 +86,11 @@ export class GroupMonitorController implements ReactiveController {
 
   private _connectionError: string | null = null;
 
+  // Time-delta context filter (milliseconds)
+  private _timeDeltaBefore = 0;
+
+  private _timeDeltaAfter = 0;
+
   // Filter data - only stores total counts, filtered counts computed on-the-fly
   private _distinctValues: DistinctValues = {
     source: {},
@@ -196,6 +201,45 @@ export class GroupMonitorController implements ReactiveController {
     return this._connectionError;
   }
 
+  public get timeDeltaBefore(): number {
+    return this._timeDeltaBefore;
+  }
+
+  public set timeDeltaBefore(value: number) {
+    this._timeDeltaBefore = Math.max(0, Math.floor(value));
+    this._bufferVersion++;
+    this.host.requestUpdate();
+  }
+
+  public get timeDeltaAfter(): number {
+    return this._timeDeltaAfter;
+  }
+
+  public set timeDeltaAfter(value: number) {
+    this._timeDeltaAfter = Math.max(0, Math.floor(value));
+    this._bufferVersion++;
+    this.host.requestUpdate();
+  }
+
+  /**
+   * Whether the time-delta filter is active
+   * Only active when at least one list-based filter is set AND a delta > 0
+   */
+  public get isTimeDeltaActive(): boolean {
+    const hasListFilters = Object.values(this._filters).some(
+      (f) => Array.isArray(f) && f.length > 0,
+    );
+    return hasListFilters && (this._timeDeltaBefore > 0 || this._timeDeltaAfter > 0);
+  }
+
+  /**
+   * Whether any list-based filters are active
+   * Used by the UI to decide whether to disable the time-delta inputs
+   */
+  public get hasActiveListFilters(): boolean {
+    return Object.values(this._filters).some((f) => Array.isArray(f) && f.length > 0);
+  }
+
   /**
    * Gets both filtered telegrams and distinct values in a single synchronized call
    */
@@ -207,6 +251,8 @@ export class GroupMonitorController implements ReactiveController {
       this._distinctValues,
       this._sortColumn,
       this._sortDirection,
+      this._timeDeltaBefore,
+      this._timeDeltaAfter,
     );
 
     // Check if filtered telegrams have changed and emit event if so
@@ -238,10 +284,20 @@ export class GroupMonitorController implements ReactiveController {
       distinctValues: DistinctValues,
       sortColumn?: string,
       sortDirection?: SortingDirection,
+      timeDeltaBefore?: number,
+      timeDeltaAfter?: number,
     ): FilteredTelegramsResult => {
       // Filter telegrams based on current filters
-      const filteredTelegrams = allTelegrams.filter((telegram) =>
+      const matchingTelegrams = allTelegrams.filter((telegram) =>
         this.matchesActiveFilters(telegram),
+      );
+
+      // Apply time-delta expansion if active
+      const filteredTelegrams = this._applyTimeDeltaExpansion(
+        matchingTelegrams,
+        allTelegrams,
+        timeDeltaBefore || 0,
+        timeDeltaAfter || 0,
       );
 
       // Sort telegrams if a sort column and direction are specified
@@ -413,9 +469,22 @@ export class GroupMonitorController implements ReactiveController {
    */
   public clearFilters(route?: Route): void {
     this._filters = {};
+    this._timeDeltaBefore = 0;
+    this._timeDeltaAfter = 0;
     this._updateUrlFromFilters(route);
     this._cleanupUnusedFilterValues();
 
+    this.host.requestUpdate();
+  }
+
+  /**
+   * Updates time-delta values and persists to URL
+   */
+  public setTimeDelta(before: number, after: number, route?: Route): void {
+    this._timeDeltaBefore = Math.max(0, Math.floor(before));
+    this._timeDeltaAfter = Math.max(0, Math.floor(after));
+    this._bufferVersion++;
+    this._updateUrlFromFilters(route);
     this.host.requestUpdate();
   }
 
@@ -516,6 +585,85 @@ export class GroupMonitorController implements ReactiveController {
       default:
         return null;
     }
+  }
+
+  /**
+   * Applies time-delta expansion to include context telegrams around matching ones.
+   * Uses binary search on the already-sorted allTelegrams array for O(n log n) performance.
+   *
+   * @param matchingTelegrams - Telegrams that match the active list filters
+   * @param allTelegrams - All telegrams in the buffer (sorted chronologically by timestamp)
+   * @param deltaBefore - Milliseconds before a matching telegram to include
+   * @param deltaAfter - Milliseconds after a matching telegram to include
+   * @returns Expanded array of telegrams (deduplicated, preserving original order)
+   */
+  private _applyTimeDeltaExpansion(
+    matchingTelegrams: TelegramRow[],
+    allTelegrams: readonly TelegramRow[],
+    deltaBefore: number,
+    deltaAfter: number,
+  ): TelegramRow[] {
+    // No delta active or no matching telegrams → return as-is
+    if ((deltaBefore <= 0 && deltaAfter <= 0) || matchingTelegrams.length === 0) {
+      return matchingTelegrams;
+    }
+
+    // If all telegrams match, no expansion needed
+    if (matchingTelegrams.length === allTelegrams.length) {
+      return matchingTelegrams;
+    }
+
+    // Collect indices into allTelegrams that should be included
+    const includedIndices = new Set<number>();
+
+    // Pre-extract timestamps as milliseconds for binary search
+    const timestamps = allTelegrams.map((t) => t.timestamp.getTime());
+
+    for (const match of matchingTelegrams) {
+      const matchTime = match.timestamp.getTime();
+      const windowStart = matchTime - deltaBefore;
+      const windowEnd = matchTime + deltaAfter;
+
+      // Binary search for lower bound (first telegram >= windowStart)
+      let lo = 0;
+      let hi = timestamps.length;
+      while (lo < hi) {
+        const mid = Math.floor((lo + hi) / 2);
+        if (timestamps[mid] < windowStart) {
+          lo = mid + 1;
+        } else {
+          hi = mid;
+        }
+      }
+      const startIdx = lo;
+
+      // Binary search for upper bound (first telegram > windowEnd)
+      lo = startIdx;
+      hi = timestamps.length;
+      while (lo < hi) {
+        const mid = Math.floor((lo + hi) / 2);
+        if (timestamps[mid] <= windowEnd) {
+          lo = mid + 1;
+        } else {
+          hi = mid;
+        }
+      }
+      const endIdx = lo;
+
+      // Mark all telegrams in the window
+      for (let i = startIdx; i < endIdx; i++) {
+        includedIndices.add(i);
+      }
+    }
+
+    // Build result preserving original order from allTelegrams
+    // Include: matching telegrams + context telegrams within windows
+    const result: TelegramRow[] = [];
+    for (const idx of Array.from(includedIndices).sort((a, b) => a - b)) {
+      result.push(allTelegrams[idx]);
+    }
+
+    return result;
   }
 
   /**
@@ -770,6 +918,14 @@ export class GroupMonitorController implements ReactiveController {
       }
     });
 
+    // Persist time-delta values in URL
+    if (this._timeDeltaBefore > 0) {
+      params.set("timedelta_before", this._timeDeltaBefore.toString());
+    }
+    if (this._timeDeltaAfter > 0) {
+      params.set("timedelta_after", this._timeDeltaAfter.toString());
+    }
+
     const newPath = params.toString()
       ? `${route.prefix}${route.path}?${params.toString()}`
       : `${route.prefix}${route.path}`;
@@ -786,6 +942,16 @@ export class GroupMonitorController implements ReactiveController {
     const destination = searchParams.get("destination");
     const direction = searchParams.get("direction");
     const telegramtype = searchParams.get("telegramtype");
+    const timeDeltaBefore = searchParams.get("timedelta_before");
+    const timeDeltaAfter = searchParams.get("timedelta_after");
+
+    // Restore time-delta values from URL
+    if (timeDeltaBefore) {
+      this._timeDeltaBefore = Math.max(0, Math.floor(Number(timeDeltaBefore) || 0));
+    }
+    if (timeDeltaAfter) {
+      this._timeDeltaAfter = Math.max(0, Math.floor(Number(timeDeltaAfter) || 0));
+    }
 
     if (!source && !destination && !direction && !telegramtype) {
       return;

--- a/src/features/group-monitor/views/group-monitor-view.ts
+++ b/src/features/group-monitor/views/group-monitor-view.ts
@@ -869,12 +869,19 @@ export class KNXGroupMonitor extends LitElement {
    * @returns The complete template for the group monitor interface
    */
   protected render(): TemplateResult {
-    const activeFilters = Object.values(this.controller.filters).filter(
+    let activeFilters = Object.values(this.controller.filters).filter(
       (f) => Array.isArray(f) && f.length,
     ).length;
 
+    if (
+      activeFilters > 0 &&
+      (this.controller.timeDeltaBefore > 0 || this.controller.timeDeltaAfter > 0)
+    ) {
+      activeFilters++;
+    }
+
     // Get filtered data once to avoid update loops
-    const { filteredTelegrams, distinctValues } = this._getFilteredData();
+    const { filteredTelegrams, distinctValues, timeDeltaAddedCount } = this._getFilteredData();
 
     return html`
       <hass-tabs-subpage-data-table
@@ -1078,9 +1085,11 @@ export class KNXGroupMonitor extends LitElement {
         <!-- Time-Delta Context Filter -->
         <knx-time-delta-filter
           slot="filter-pane"
+          .hass=${this.hass}
           .knx=${this.knx}
           .deltaBefore=${this.controller.timeDeltaBefore}
           .deltaAfter=${this.controller.timeDeltaAfter}
+          .addedCount=${timeDeltaAddedCount || 0}
           .disabled=${!this.controller.hasActiveListFilters}
           .expanded=${this.controller.expandedFilter === "timedelta"}
           @time-delta-changed=${this._handleTimeDeltaChanged}

--- a/src/features/group-monitor/views/group-monitor-view.ts
+++ b/src/features/group-monitor/views/group-monitor-view.ts
@@ -67,6 +67,8 @@ import type { TimeDeltaChangedEvent } from "../../../components/data-table/filte
  * - `?destination=1/2/3,4/5/6` - Filter by destination addresses (comma-separated)
  * - `?direction=Incoming` - Filter by telegram direction (comma-separated)
  * - `?telegramtype=GroupValueWrite,GroupValueRead` - Filter by telegram types (comma-separated)
+ * - `?timedelta_before=100` - Include telegrams up to 100ms before a match (only applies when list filters are active)
+ * - `?timedelta_after=100` - Include telegrams up to 100ms after a match (only applies when list filters are active)
  *
  * **Examples:**
  * ```

--- a/src/features/group-monitor/views/group-monitor-view.ts
+++ b/src/features/group-monitor/views/group-monitor-view.ts
@@ -22,6 +22,7 @@ import { isTouch } from "@ha/util/is_touch";
 import "../../../components/data-table/cell/knx-table-cell";
 import "../../../components/data-table/cell/knx-table-cell-filterable";
 import "../../../components/data-table/filter/knx-list-filter";
+import "../../../components/data-table/filter/knx-time-delta-filter";
 
 import { customElement, property, query } from "lit/decorators";
 import { storage } from "@ha/common/decorators/storage";
@@ -43,6 +44,7 @@ import type {
   Config as ListFilterConfig,
   KnxListFilter,
 } from "../../../components/data-table/filter/knx-list-filter";
+import type { TimeDeltaChangedEvent } from "../../../components/data-table/filter/knx-time-delta-filter";
 
 /**
  * KNX Group Monitor Component
@@ -538,6 +540,16 @@ export class KNXGroupMonitor extends LitElement {
     ev: HASSDomEvent<ListFilterExpandedChangedEvent>,
   ): void => {
     this._onFilterExpansionChange("telegramtype", ev.detail.expanded);
+  };
+
+  /** Handles time-delta filter value changes */
+  private _handleTimeDeltaChanged = (ev: HASSDomEvent<TimeDeltaChangedEvent>): void => {
+    this.controller.setTimeDelta(ev.detail.deltaBefore, ev.detail.deltaAfter, this.route);
+  };
+
+  /** Handles time-delta filter panel expansion */
+  private _handleTimeDeltaExpanded = (ev: CustomEvent<{ expanded: boolean }>): void => {
+    this._onFilterExpansionChange("timedelta", ev.detail.expanded);
   };
 
   // Table cell filter toggle handlers (for quick filtering from table cells)
@@ -1062,6 +1074,18 @@ export class KNXGroupMonitor extends LitElement {
           @selection-changed=${this._handleTelegramTypeFilterChange}
           @expanded-changed=${this._handleTelegramTypeFilterExpanded}
         ></knx-list-filter>
+
+        <!-- Time-Delta Context Filter -->
+        <knx-time-delta-filter
+          slot="filter-pane"
+          .knx=${this.knx}
+          .deltaBefore=${this.controller.timeDeltaBefore}
+          .deltaAfter=${this.controller.timeDeltaAfter}
+          .disabled=${!this.controller.hasActiveListFilters}
+          .expanded=${this.controller.expandedFilter === "timedelta"}
+          @time-delta-changed=${this._handleTimeDeltaChanged}
+          @expanded-changed=${this._handleTimeDeltaExpanded}
+        ></knx-time-delta-filter>
       </hass-tabs-subpage-data-table>
     `;
   }

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -112,10 +112,11 @@
   "expose_create_loading": "Expose-Konfiguration wird geladen.",
   "expose_create_load_error": "Fehler beim Laden der Expose-Konfiguration.",
   "expose_validation_error": "Validierungsfehler",
-  "group_monitor_time_delta_title": "Zeitdelta-Kontext",
-  "group_monitor_time_delta_description": "Telegramme innerhalb eines Zeitfensters um ein filter-passendes Telegramm einbeziehen, auch wenn sie nicht dem Filter entsprechen.",
-  "group_monitor_time_delta_before": "- Vorher (MS)",
-  "group_monitor_time_delta_after": "+ Nachher (MS)",
+  "group_monitor_time_delta_title": "Kontextzeitspanne",
+  "group_monitor_time_delta_description": "Zeigt zusätzlich alle Telegramme innerhalb der definierten Zeitspanne vor/nach einem gefilterten Telegramm – unabhängig von den gesetzten Filtern.",
+  "group_monitor_time_delta_before": "- Vorher (ms)",
+  "group_monitor_time_delta_after": "+ Nachher (ms)",
   "group_monitor_time_delta_placeholder": "0 = aus",
-  "group_monitor_time_delta_disabled": "Setze zuerst andere Filter, um den Zeitdelta-Kontext zu nutzen."
+  "group_monitor_time_delta_disabled": "Filter setzen, um die Kontextzeitspanne zu nutzen.",
+  "group_monitor_time_delta_summary": "Innerhalb -{before} ms +{after} ms"
 }

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -111,5 +111,11 @@
   "knx_telegram_info_dialog_payload": "Daten",
   "expose_create_loading": "Expose-Konfiguration wird geladen.",
   "expose_create_load_error": "Fehler beim Laden der Expose-Konfiguration.",
-  "expose_validation_error": "Validierungsfehler"
+  "expose_validation_error": "Validierungsfehler",
+  "group_monitor_time_delta_title": "Zeitdelta-Kontext",
+  "group_monitor_time_delta_description": "Telegramme innerhalb eines Zeitfensters um ein filter-passendes Telegramm einbeziehen, auch wenn sie nicht dem Filter entsprechen.",
+  "group_monitor_time_delta_before": "- Vorher (MS)",
+  "group_monitor_time_delta_after": "+ Nachher (MS)",
+  "group_monitor_time_delta_placeholder": "0 = aus",
+  "group_monitor_time_delta_disabled": "Setze zuerst andere Filter, um den Zeitdelta-Kontext zu nutzen."
 }

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -113,10 +113,9 @@
   "expose_create_load_error": "Fehler beim Laden der Expose-Konfiguration.",
   "expose_validation_error": "Validierungsfehler",
   "group_monitor_time_delta_title": "Kontextzeitspanne",
-  "group_monitor_time_delta_description": "Zeigt zusätzlich alle Telegramme innerhalb der definierten Zeitspanne vor/nach einem gefilterten Telegramm – unabhängig von den gesetzten Filtern.",
+  "group_monitor_time_delta_description": "Zeigt zusätzlich alle Telegramme innerhalb der definierten Zeitspanne vor/nach einem gefilterten Telegramm – unabhängig von den gesetzten Filtern. (0 = aus)",
   "group_monitor_time_delta_before": "- Vorher (ms)",
   "group_monitor_time_delta_after": "+ Nachher (ms)",
-  "group_monitor_time_delta_placeholder": "0 = aus",
   "group_monitor_time_delta_disabled": "Filter setzen, um die Kontextzeitspanne zu nutzen.",
-  "group_monitor_time_delta_summary": "Innerhalb -{before} ms +{after} ms"
+  "group_monitor_time_delta_summary": "Innerhalb -{before} ms / +{after} ms"
 }

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -114,10 +114,9 @@
   "expose_create_load_error": "Error loading expose configuration.",
   "expose_validation_error": "Validation error",
   "group_monitor_time_delta_title": "Context time span",
-  "group_monitor_time_delta_description": "Also shows all telegrams within the defined time span before/after a filtered telegram – regardless of the applied filters.",
+  "group_monitor_time_delta_description": "Also shows all telegrams within the defined time span before/after a filtered telegram – regardless of the applied filters. (0 = off)",
   "group_monitor_time_delta_before": "- Before (ms)",
   "group_monitor_time_delta_after": "+ After (ms)",
-  "group_monitor_time_delta_placeholder": "0 = off",
   "group_monitor_time_delta_disabled": "Set a filter to use the context time span.",
-  "group_monitor_time_delta_summary": "Within -{before} ms +{after} ms"
+  "group_monitor_time_delta_summary": "Within -{before} ms / +{after} ms"
 }

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -113,10 +113,11 @@
   "expose_create_loading": "Loading expose configuration.",
   "expose_create_load_error": "Error loading expose configuration.",
   "expose_validation_error": "Validation error",
-  "group_monitor_time_delta_title": "Time-Delta Context",
-  "group_monitor_time_delta_description": "Include telegrams within a window around any filter-matching telegram, even if they don't match the filter.",
-  "group_monitor_time_delta_before": "- Before (MS)",
-  "group_monitor_time_delta_after": "+ After (MS)",
+  "group_monitor_time_delta_title": "Context time span",
+  "group_monitor_time_delta_description": "Also shows all telegrams within the defined time span before/after a filtered telegram – regardless of the applied filters.",
+  "group_monitor_time_delta_before": "- Before (ms)",
+  "group_monitor_time_delta_after": "+ After (ms)",
   "group_monitor_time_delta_placeholder": "0 = off",
-  "group_monitor_time_delta_disabled": "Set other filters first to use time-delta context."
+  "group_monitor_time_delta_disabled": "Set a filter to use the context time span.",
+  "group_monitor_time_delta_summary": "Within -{before} ms +{after} ms"
 }

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -112,5 +112,11 @@
   "knx_telegram_info_dialog_payload": "Payload",
   "expose_create_loading": "Loading expose configuration.",
   "expose_create_load_error": "Error loading expose configuration.",
-  "expose_validation_error": "Validation error"
+  "expose_validation_error": "Validation error",
+  "group_monitor_time_delta_title": "Time-Delta Context",
+  "group_monitor_time_delta_description": "Include telegrams within a window around any filter-matching telegram, even if they don't match the filter.",
+  "group_monitor_time_delta_before": "- Before (MS)",
+  "group_monitor_time_delta_after": "+ After (MS)",
+  "group_monitor_time_delta_placeholder": "0 = off",
+  "group_monitor_time_delta_disabled": "Set other filters first to use time-delta context."
 }


### PR DESCRIPTION
Implement a "Time-Delta Context" filter for the KNX Group Monitor, backported from a SpectrumKNX feature. This allows users to include telegrams within a ±millisecond window around any filter-matching telegram, even if the surrounding telegrams don't match the active filters themselves.
Technical details:
- Added `knx-time-delta-filter` component for ms-based window inputs.
- Implemented O(n log n) filtering expansion using binary search on sorted timestamps in GroupMonitorController.
- Persisted `timedelta_before` and `timedelta_after` in the URL.
- Added 11 Vitest tests covering edge cases and window overlaps.
- Localization support for English and German.