### PR TITLE
Skip pre-commit lint when yarn is unavailable

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,11 @@
+# Yarn itself is vendored in the homeassistant-frontend submodule (see yarnPath
+# in .yarnrc.yml), so it cannot run before that submodule is checked out.
+yarn_path=$(sed -n 's/^yarnPath: *//p' .yarnrc.yml)
+if [ -n "$yarn_path" ] && [ ! -f "$yarn_path" ]; then
+  echo "pre-commit: $yarn_path is missing, so lint cannot run; skipping it."
+  echo "pre-commit: run 'git submodule update --init' to lint locally. CI runs it regardless."
+  exit 0
+fi
+
 yarn run lint:eslint
 yarn run lint:prettier


### PR DESCRIPTION
## What changed

`.husky/pre-commit` now checks that the yarn release named by `yarnPath` actually exists before invoking yarn, and skips linting with an actionable message if it does not.

## Why

Yarn itself is vendored inside the `homeassistant-frontend` submodule:

```yaml
# .yarnrc.yml
yarnPath: homeassistant-frontend/.yarn/releases/yarn-4.17.0.cjs
```

So before that submodule is checked out, nothing yarn-based can run. The hook did not account for that and died with a raw Node stack trace, **blocking every commit** regardless of content:

```
Error: Cannot find module '.../homeassistant-frontend/.yarn/releases/yarn-4.17.0.cjs'
husky - pre-commit script failed (code 1)
```

This bites in two situations: a fresh clone before `git submodule update --init`, and any git worktree, since worktrees never get submodules. It surfaced while fixing #407 — a commit in a worktree was impossible without `--no-verify`.

## Is lint being silently lost?

No, on two counts:

1. **CI is the real gate.** `.github/workflows/ci.yml` runs the same `yarn run lint:eslint` and `yarn run lint:prettier` on every PR.
2. **The skip only fires where lint could not have run anyway.** The alternative isn't "lint runs" — it's "the commit is rejected with a stack trace."

The message tells you exactly how to get linting back (`git submodule update --init`), so the degraded state is visible rather than silent.

## Verification

Both branches of the guard were exercised:

| Environment | Result |
|---|---|
| Worktree, submodule absent | Skips with the message, exit 0 |
| Main checkout, submodule present | Runs eslint + prettier for real, exit 0 |

This commit is itself the end-to-end proof: it was made from a worktree with hooks enabled and no `--no-verify`.

## Note for reviewers

One subtlety worth knowing, since it affects when the fix takes effect. `core.hooksPath` is set to an **absolute** path (`/…/knx-frontend/.husky/_`), so a commit made in a worktree executes the *main checkout's* hook script with `cwd` set to the worktree. The guard therefore starts working in existing worktrees only once main has this commit — the hook body is read from main, while `.yarnrc.yml` and the missing yarn release are resolved against the worktree. That combination is what the verification above reproduces.

`sed`-parsing one key out of `.yarnrc.yml` is admittedly crude, but it keeps the yarn version from being hardcoded in a second place, so a `yarnPath` bump can't desync the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)