### PR TITLE
Animate knx-sticky-expansion-panel and let it toggle itself

### DIFF
--- a/src/components/knx-project-devices-view.ts
+++ b/src/components/knx-project-devices-view.ts
@@ -280,11 +280,14 @@ export class KNXProjectDevicesView extends LitElement {
   }
 
   /**
-   * Intercept summary clicks / key presses of the expansion panels in capture
-   * phase and toggle the controlled expansion state instead. Calling
-   * preventDefault makes ha-expansion-panel skip its internal toggle, whose
-   * height animation leaves stale inline heights when nested panels or
-   * dynamic content change the content size afterwards.
+   * Intercept summary clicks / key presses of both the device and channel
+   * panels in capture phase and toggle the expansion state here instead:
+   * it is derived from the active filters, not just from what was clicked.
+   *
+   * Both panel types skip their own toggle once preventDefault is called.
+   * For ha-expansion-panel that also avoids its height animation, which
+   * leaves stale inline heights when nested panels or dynamic content
+   * change the content size afterwards.
    */
   private _summaryInterceptor = (ev: Event): void => {
     if (ev.type === "keydown") {
@@ -376,7 +379,6 @@ export class KNXProjectDevicesView extends LitElement {
       .expanded=${expanded}
       .noCollapse=${!hasContent}
       data-panel-key=${device.ia}
-      @expanded-changed=${this._devicePanelToggled}
     >
       <div slot="header" class="device-header">
         <span class="icon ia">
@@ -429,15 +431,6 @@ export class KNXProjectDevicesView extends LitElement {
           )}`
         : nothing}
     </knx-sticky-expansion-panel>`;
-  }
-
-  private _devicePanelToggled(ev: CustomEvent<{ expanded: boolean }>): void {
-    if (ev.target !== ev.currentTarget) {
-      // ignore events bubbling up from nested channel panels
-      return;
-    }
-    const panelKey = (ev.currentTarget as HTMLElement).dataset.panelKey!;
-    this._setPanelExpanded(panelKey, ev.detail.expanded);
   }
 
   private _renderAggregatedRelated(refs: RelatedRefs): TemplateResult {

--- a/src/components/knx-sticky-expansion-panel.ts
+++ b/src/components/knx-sticky-expansion-panel.ts
@@ -1,11 +1,14 @@
 import { mdiChevronDown } from "@mdi/js";
 import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
 
 import "@ha/components/ha-svg-icon";
 import { fireEvent } from "@ha/common/dom/fire_event";
+
+/** Longer than the collapse, so it only ever fires when the transition did not. */
+const UNMOUNT_FALLBACK_MS = 1000;
 
 /**
  * An expansion panel card whose header sticks to the top of the nearest
@@ -13,10 +16,13 @@ import { fireEvent } from "@ha/common/dom/fire_event";
  *
  * It exists because ha-expansion-panel animates its height by measuring the
  * content once and writing an inline height, which goes stale when nested or
- * dynamic content grows afterwards. This panel renders content while expanded
- * instead, and clips the card with `overflow: clip`, which - unlike `hidden` -
- * does not create a scroll container, so the sticky header keeps pinning to
- * the list rather than to the card.
+ * dynamic content grows afterwards. This panel animates an `0fr`/`1fr` grid
+ * track instead: the browser keeps deriving the size, so there is nothing to
+ * measure and nothing to go stale.
+ *
+ * The card clips itself with `overflow: clip`, which - unlike `hidden` - does
+ * not create a scroll container, so the sticky header keeps pinning to the
+ * list rather than to the card.
  *
  * Expansion behaves like ha-expansion-panel: the panel toggles itself and
  * reports it, so it works with no wiring at all. A parent that owns the
@@ -24,11 +30,11 @@ import { fireEvent } from "@ha/common/dom/fire_event";
  * the capture phase and setting `expanded` itself.
  *
  * Collapsing a panel that is scrolled past would drop its header above the
- * scrollport and yank the following panels upwards, so on collapse the card
- * scrolls itself back to the top edge - see `_anchorAfterCollapse`.
+ * scrollport and yank the following panels upwards, so the card scrolls back
+ * to the top edge as the collapse starts - see `_anchorOnCollapse`.
  *
  * @slot header - Header content, always visible, sticky while scrolling.
- * @slot - Panel content, rendered when expanded.
+ * @slot - Panel content, rendered while expanded and during the collapse.
  * @fires expanded-will-change - Upcoming state as `{ expanded: boolean }`.
  * @fires expanded-changed - New state as `{ expanded: boolean }`.
  */
@@ -39,13 +45,23 @@ export class KnxStickyExpansionPanel extends LitElement {
   @property({ attribute: "no-collapse", type: Boolean, reflect: true })
   public noCollapse = false;
 
+  /**
+   * Content stays rendered for the length of the collapse, so there is
+   * something to animate away. It is not rendered while collapsed: the
+   * devices view has a card per device, and mounting every one of them
+   * would cost far more than the animation is worth.
+   */
+  @state() private _showContent = this.expanded;
+
+  private _unmountTimeout?: number;
+
   protected render(): TemplateResult {
     const collapsible = !this.noCollapse;
     return html`
       <div
         id="summary"
         part="summary"
-        class="header ${this.expanded ? "expanded" : ""}"
+        class="header ${this._showContent ? "with-content" : ""}"
         role=${ifDefined(collapsible ? "button" : undefined)}
         tabindex=${ifDefined(collapsible ? "0" : undefined)}
         aria-expanded=${this.expanded}
@@ -60,7 +76,14 @@ export class KnxStickyExpansionPanel extends LitElement {
           : nothing}
         <slot name="header"></slot>
       </div>
-      ${this.expanded ? html`<div class="content"><slot></slot></div>` : nothing}
+      <div
+        class="expander ${this.expanded ? "expanded" : ""}"
+        @transitionend=${this._handleTransitionEnd}
+      >
+        <div class="clip">
+          ${this._showContent ? html`<div class="content"><slot></slot></div>` : nothing}
+        </div>
+      </div>
     `;
   }
 
@@ -83,24 +106,80 @@ export class KnxStickyExpansionPanel extends LitElement {
     fireEvent(this, "expanded-changed", { expanded });
   }
 
+  protected willUpdate(changedProperties: PropertyValues): void {
+    if (changedProperties.has("expanded") && this.expanded) {
+      // mount in the same update that starts the track towards 1fr, so the
+      // content is there to give the track a size to grow into
+      this._showContent = true;
+      this._clearUnmount();
+    }
+  }
+
   protected updated(changedProperties: PropertyValues): void {
     // observing the property rather than the click covers both the self-toggle
-    // and a parent that owns `expanded`, so anchoring works either way
+    // and a parent that owns `expanded`, so this works either way
     if (changedProperties.get("expanded") === true && !this.expanded) {
-      this._anchorAfterCollapse();
+      this._anchorOnCollapse();
+      this._scheduleUnmount();
+    }
+  }
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._clearUnmount();
+  }
+
+  private _handleTransitionEnd(ev: TransitionEvent): void {
+    // transitions from the content bubble up here too - a nested
+    // ha-expansion-panel animates its height inside this very card - so only
+    // this card's own track may unmount it
+    if (ev.propertyName !== "grid-template-rows" || ev.target !== ev.currentTarget) {
+      return;
+    }
+    if (!this.expanded) {
+      this._clearUnmount();
+      this._showContent = false;
     }
   }
 
   /**
-   * Keeps a collapsed card in place instead of letting it fall out of view.
+   * A collapse that never animates never ends: a card hidden by a filter
+   * mid-collapse gets no transitionend, and its content would stay mounted
+   * for good. Unmount on a timer as well and take whichever comes first.
+   */
+  private _scheduleUnmount(): void {
+    this._clearUnmount();
+    this._unmountTimeout = window.setTimeout(() => {
+      this._unmountTimeout = undefined;
+      if (!this.expanded) {
+        this._showContent = false;
+      }
+    }, UNMOUNT_FALLBACK_MS);
+  }
+
+  private _clearUnmount(): void {
+    if (this._unmountTimeout !== undefined) {
+      clearTimeout(this._unmountTimeout);
+      this._unmountTimeout = undefined;
+    }
+  }
+
+  /**
+   * Keeps a collapsing card in place instead of letting it fall out of view.
    *
    * Collapsing only removes height below the card's top edge, so a card that
    * was scrolled into keeps its top above the scrollport: its header is gone
    * from view and everything below slides up. Pulling the scroll offset back
    * by that overshoot lands the header at the top edge, where the reader left
    * it. A card whose top is already visible does not move, so it is left alone.
+   *
+   * The overshoot does not depend on the card's height, so this runs as the
+   * collapse starts rather than after it: the card top reaches the scrollport
+   * edge while the content is still at full height, and the shrinking that
+   * follows moves nothing. Anchoring afterwards, or midway, would mean
+   * chasing the scroll offset for every frame of the animation instead.
    */
-  private _anchorAfterCollapse(): void {
+  private _anchorOnCollapse(): void {
     const scroller = this._scrollParent();
     if (!scroller) {
       return;
@@ -167,8 +246,13 @@ export class KnxStickyExpansionPanel extends LitElement {
       outline: none;
     }
 
-    .header.expanded {
-      /* drawn as a shadow, not a border: it takes no layout space and is
+    .header.with-content {
+      /* follows the content rather than the expanded state, so the divider
+         lasts exactly as long as there is content to divide - it would
+         otherwise vanish at the start of the collapse, with content still
+         on screen.
+
+         drawn as a shadow, not a border: it takes no layout space and is
          clipped by the card once the header is pushed onto the bottom edge,
          so it cannot stack with the card border into a 2px line */
       box-shadow: 0 1px 0 var(--divider-color);
@@ -189,7 +273,31 @@ export class KnxStickyExpansionPanel extends LitElement {
       transform: rotate(180deg);
     }
 
+    .expander {
+      /* an fr track animates without anyone measuring the content, so nested
+         panels and late values can resize it mid-animation and it still lands
+         on the right height - the whole reason this is not an inline height */
+      display: grid;
+      grid-template-rows: 0fr;
+      /* the duration collapses to 1ms under prefers-reduced-motion */
+      transition: grid-template-rows var(--ha-animation-duration-normal, 250ms)
+        cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .expander.expanded {
+      grid-template-rows: 1fr;
+    }
+
+    .clip {
+      /* clips the content to the track while it animates, and lets the track
+         reach 0fr at all by taking the grid item's min-height off "auto".
+         it can stay on at rest: the card already clips itself anyway */
+      overflow: hidden;
+    }
+
     .content {
+      /* padding belongs inside the clip, not on the grid item: a stretched
+         item keeps its padding in a 0fr track, leaving the card propped open */
       padding: var(--sticky-expansion-panel-content-padding, 0 8px 4px);
     }
   `;

--- a/src/components/knx-sticky-expansion-panel.ts
+++ b/src/components/knx-sticky-expansion-panel.ts
@@ -8,18 +8,20 @@ import "@ha/components/ha-svg-icon";
 import { fireEvent } from "@ha/common/dom/fire_event";
 
 /**
- * A controlled expansion panel card whose header sticks to the top of the
- * nearest scroll container while its content is scrolled.
+ * An expansion panel card whose header sticks to the top of the nearest
+ * scroll container while its content is scrolled.
  *
- * Unlike ha-expansion-panel it never toggles itself: a header click or
- * Enter/Space key press only fires `expanded-changed` with the requested
- * state; the parent owns the `expanded` property. Content is only rendered
- * while expanded, and without a height animation stale inline heights
- * cannot occur when nested or dynamic content grows.
+ * It exists because ha-expansion-panel animates its height by measuring the
+ * content once and writing an inline height, which goes stale when nested or
+ * dynamic content grows afterwards. This panel renders content while expanded
+ * instead, and clips the card with `overflow: clip`, which - unlike `hidden` -
+ * does not create a scroll container, so the sticky header keeps pinning to
+ * the list rather than to the card.
  *
- * The card clips its content at the rounded corners with `overflow: clip`,
- * which - unlike `hidden` - does not create a scroll container, so the
- * sticky header keeps working.
+ * Expansion behaves like ha-expansion-panel: the panel toggles itself and
+ * reports it, so it works with no wiring at all. A parent that owns the
+ * state can take over by calling `preventDefault()` on the click/keydown in
+ * the capture phase and setting `expanded` itself.
  *
  * Collapsing a panel that is scrolled past would drop its header above the
  * scrollport and yank the following panels upwards, so on collapse the card
@@ -27,7 +29,8 @@ import { fireEvent } from "@ha/common/dom/fire_event";
  *
  * @slot header - Header content, always visible, sticky while scrolling.
  * @slot - Panel content, rendered when expanded.
- * @fires expanded-changed - Requested state as `{ expanded: boolean }`.
+ * @fires expanded-will-change - Upcoming state as `{ expanded: boolean }`.
+ * @fires expanded-changed - New state as `{ expanded: boolean }`.
  */
 @customElement("knx-sticky-expansion-panel")
 export class KnxStickyExpansionPanel extends LitElement {
@@ -40,12 +43,14 @@ export class KnxStickyExpansionPanel extends LitElement {
     const collapsible = !this.noCollapse;
     return html`
       <div
+        id="summary"
+        part="summary"
         class="header ${this.expanded ? "expanded" : ""}"
         role=${ifDefined(collapsible ? "button" : undefined)}
         tabindex=${ifDefined(collapsible ? "0" : undefined)}
         aria-expanded=${this.expanded}
-        @click=${collapsible ? this._toggleRequested : nothing}
-        @keydown=${collapsible ? this._toggleRequested : nothing}
+        @click=${collapsible ? this._toggle : nothing}
+        @keydown=${collapsible ? this._toggle : nothing}
       >
         ${collapsible
           ? html`<ha-svg-icon
@@ -59,7 +64,12 @@ export class KnxStickyExpansionPanel extends LitElement {
     `;
   }
 
-  private _toggleRequested(ev: Event): void {
+  private _toggle(ev: Event): void {
+    // a parent that owns `expanded` suppresses the self-toggle from the
+    // capture phase, the same way ha-expansion-panel can be controlled
+    if (ev.defaultPrevented) {
+      return;
+    }
     if (ev.type === "keydown") {
       const key = (ev as KeyboardEvent).key;
       if (key !== "Enter" && key !== " ") {
@@ -67,12 +77,15 @@ export class KnxStickyExpansionPanel extends LitElement {
       }
     }
     ev.preventDefault();
-    fireEvent(this, "expanded-changed", { expanded: !this.expanded });
+    const expanded = !this.expanded;
+    fireEvent(this, "expanded-will-change", { expanded });
+    this.expanded = expanded;
+    fireEvent(this, "expanded-changed", { expanded });
   }
 
   protected updated(changedProperties: PropertyValues): void {
-    // the parent owns `expanded`, but the transition is still observable here,
-    // so anchoring works no matter who collapsed the panel
+    // observing the property rather than the click covers both the self-toggle
+    // and a parent that owns `expanded`, so anchoring works either way
     if (changedProperties.get("expanded") === true && !this.expanded) {
       this._anchorAfterCollapse();
     }

--- a/src/components/knx-sticky-expansion-panel.ts
+++ b/src/components/knx-sticky-expansion-panel.ts
@@ -1,5 +1,5 @@
 import { mdiChevronDown } from "@mdi/js";
-import type { TemplateResult } from "lit";
+import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators";
 import { ifDefined } from "lit/directives/if-defined";
@@ -20,6 +20,10 @@ import { fireEvent } from "@ha/common/dom/fire_event";
  * The card clips its content at the rounded corners with `overflow: clip`,
  * which - unlike `hidden` - does not create a scroll container, so the
  * sticky header keeps working.
+ *
+ * Collapsing a panel that is scrolled past would drop its header above the
+ * scrollport and yank the following panels upwards, so on collapse the card
+ * scrolls itself back to the top edge - see `_anchorAfterCollapse`.
  *
  * @slot header - Header content, always visible, sticky while scrolling.
  * @slot - Panel content, rendered when expanded.
@@ -66,6 +70,59 @@ export class KnxStickyExpansionPanel extends LitElement {
     fireEvent(this, "expanded-changed", { expanded: !this.expanded });
   }
 
+  protected updated(changedProperties: PropertyValues): void {
+    // the parent owns `expanded`, but the transition is still observable here,
+    // so anchoring works no matter who collapsed the panel
+    if (changedProperties.get("expanded") === true && !this.expanded) {
+      this._anchorAfterCollapse();
+    }
+  }
+
+  /**
+   * Keeps a collapsed card in place instead of letting it fall out of view.
+   *
+   * Collapsing only removes height below the card's top edge, so a card that
+   * was scrolled into keeps its top above the scrollport: its header is gone
+   * from view and everything below slides up. Pulling the scroll offset back
+   * by that overshoot lands the header at the top edge, where the reader left
+   * it. A card whose top is already visible does not move, so it is left alone.
+   */
+  private _anchorAfterCollapse(): void {
+    const scroller = this._scrollParent();
+    if (!scroller) {
+      return;
+    }
+    // clientTop skips the border, leaving the padding box - the edge sticky
+    // headers pin to, and the one the card top should line up with
+    const scrollportTop = scroller.getBoundingClientRect().top + scroller.clientTop;
+    const overshoot = this.getBoundingClientRect().top - scrollportTop;
+    if (overshoot < 0) {
+      scroller.scrollTop += overshoot;
+    }
+  }
+
+  /** Nearest scrollable ancestor, crossing shadow boundaries on the way up. */
+  private _scrollParent(): Element | null {
+    let node: Node | null = this.parentNode;
+    while (node) {
+      const host = (node as ShadowRoot).host;
+      if (host) {
+        node = host;
+        continue;
+      }
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const element = node as Element;
+        // no scrollHeight check: a scroller that is not overflowing right now
+        // is still the element that owns this card's scroll offset
+        if (/^(auto|scroll|overlay)$/.test(getComputedStyle(element).overflowY)) {
+          return element;
+        }
+      }
+      node = node.parentNode;
+    }
+    return null;
+  }
+
   static styles = css`
     :host {
       display: block;
@@ -98,7 +155,10 @@ export class KnxStickyExpansionPanel extends LitElement {
     }
 
     .header.expanded {
-      border-bottom: 1px solid var(--divider-color);
+      /* drawn as a shadow, not a border: it takes no layout space and is
+         clipped by the card once the header is pushed onto the bottom edge,
+         so it cannot stack with the card border into a 2px line */
+      box-shadow: 0 1px 0 var(--divider-color);
     }
 
     .header:focus-visible {

--- a/src/components/knx-sticky-expansion-panel.ts
+++ b/src/components/knx-sticky-expansion-panel.ts
@@ -1,7 +1,8 @@
 import { mdiChevronDown } from "@mdi/js";
 import type { PropertyValues, TemplateResult } from "lit";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property, query, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
 import { ifDefined } from "lit/directives/if-defined";
 
 import "@ha/components/ha-svg-icon";
@@ -53,15 +54,28 @@ export class KnxStickyExpansionPanel extends LitElement {
    */
   @state() private _showContent = this.expanded;
 
+  /** Whether the header is pinned, with content running underneath it. */
+  @state() private _stuck = false;
+
+  @query(".sentinel") private _sentinel?: HTMLDivElement;
+
   private _unmountTimeout?: number;
+
+  private _stuckObserver?: IntersectionObserver;
 
   protected render(): TemplateResult {
     const collapsible = !this.noCollapse;
     return html`
+      <div class="sentinel"></div>
       <div
         id="summary"
         part="summary"
-        class="header ${this._showContent ? "with-content" : ""}"
+        class=${classMap({
+          header: true,
+          "with-content": this._showContent,
+          // only content can be covered, so a collapsed card never lifts
+          stuck: this._stuck && this._showContent,
+        })}
         role=${ifDefined(collapsible ? "button" : undefined)}
         tabindex=${ifDefined(collapsible ? "0" : undefined)}
         aria-expanded=${this.expanded}
@@ -124,9 +138,53 @@ export class KnxStickyExpansionPanel extends LitElement {
     }
   }
 
+  protected firstUpdated(): void {
+    this._observeStuck();
+  }
+
+  public connectedCallback(): void {
+    super.connectedCallback();
+    // keyed lists move their items rather than rebuild them, and a move is a
+    // disconnect plus a connect - so re-observe here or the shadow would go
+    // dead the first time a filter reorders the list
+    if (this.hasUpdated) {
+      this._observeStuck();
+    }
+  }
+
   public disconnectedCallback(): void {
     super.disconnectedCallback();
     this._clearUnmount();
+    this._stuckObserver?.disconnect();
+    this._stuckObserver = undefined;
+  }
+
+  /**
+   * Watches a sentinel pinned to the card's top edge, which is where the
+   * header sits until it starts sticking. Once the sentinel has left the
+   * scrollport the header is holding position over content, which is when
+   * it should lift. CSS cannot express this on its own - there is no
+   * `:stuck`, and scroll-driven animations are not broadly supported yet.
+   */
+  private _observeStuck(): void {
+    this._stuckObserver?.disconnect();
+    const scroller = this._scrollParent();
+    const sentinel = this._sentinel;
+    if (!scroller || !sentinel) {
+      // nothing scrolls, so nothing can be covered
+      return;
+    }
+    this._stuckObserver = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[entries.length - 1];
+        // leaving upwards means pinned; leaving downwards just means the card
+        // is below the fold, which must not light up every card underneath
+        const rootTop = entry.rootBounds?.top ?? 0;
+        this._stuck = !entry.isIntersecting && entry.boundingClientRect.top < rootTop;
+      },
+      { root: scroller, threshold: 0 },
+    );
+    this._stuckObserver.observe(sentinel);
   }
 
   private _handleTransitionEnd(ev: TransitionEvent): void {
@@ -218,6 +276,8 @@ export class KnxStickyExpansionPanel extends LitElement {
   static styles = css`
     :host {
       display: block;
+      /* anchors the sentinel to the card's top edge */
+      position: relative;
       border: 1px solid var(--outline-color);
       border-radius: var(--ha-card-border-radius, var(--ha-border-radius-lg, 12px));
       background-color: var(--card-background-color);
@@ -226,10 +286,22 @@ export class KnxStickyExpansionPanel extends LitElement {
       overflow: clip;
     }
 
+    .sentinel {
+      /* out of flow, so it cannot shift the header it reports on. it is only
+         ever measured, never seen */
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 1px;
+      height: 1px;
+      pointer-events: none;
+    }
+
     .header {
       position: sticky;
       top: 0;
       z-index: 2;
+      transition: box-shadow var(--ha-animation-duration-fast, 150ms) linear;
       display: flex;
       align-items: center;
       min-width: 0;
@@ -256,6 +328,15 @@ export class KnxStickyExpansionPanel extends LitElement {
          clipped by the card once the header is pushed onto the bottom edge,
          so it cannot stack with the card border into a 2px line */
       box-shadow: 0 1px 0 var(--divider-color);
+    }
+
+    .header.with-content.stuck {
+      /* lifts only while the header actually holds position over content, so
+         the shadow reads as depth rather than as decoration. the card clips
+         it away again at the end of the sticky run */
+      box-shadow:
+        0 1px 0 var(--divider-color),
+        var(--ha-box-shadow-s);
     }
 
     .header:focus-visible {

--- a/src/components/knx-sticky-expansion-panel.ts
+++ b/src/components/knx-sticky-expansion-panel.ts
@@ -333,10 +333,13 @@ export class KnxStickyExpansionPanel extends LitElement {
     .header.with-content.stuck {
       /* lifts only while the header actually holds position over content, so
          the shadow reads as depth rather than as decoration. the card clips
-         it away again at the end of the sticky run */
-      box-shadow:
-        0 1px 0 var(--divider-color),
-        var(--ha-box-shadow-s);
+         it away again at the end of the sticky run.
+
+         the shadow replaces the divider instead of joining it: the line and
+         the lift together read heavier than the separation calls for, and a
+         header that casts a shadow does not need a rule to say it sits on
+         top of something */
+      box-shadow: var(--ha-box-shadow-s);
     }
 
     .header:focus-visible {

--- a/src/views/dpt_reference.ts
+++ b/src/views/dpt_reference.ts
@@ -1,5 +1,6 @@
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators";
+import { repeat } from "lit/directives/repeat";
 import type { TemplateResult } from "lit";
 
 import "@ha/components/ha-alert";
@@ -33,8 +34,6 @@ export class KnxDptReference extends LitElement {
   @property({ type: Object }) public route?: Route;
 
   @state() private _filter = "";
-
-  @state() private _expandedGroups = new Set<number>();
 
   private _onFilterChanged(ev: InputEvent): void {
     this._filter = (ev.target as HaInputSearch).value ?? "";
@@ -195,27 +194,14 @@ export class KnxDptReference extends LitElement {
   }
 
   private _renderExpandableGroup(group: DptReferenceGroup): TemplateResult {
+    // the panel owns its expansion; keying the list by group keeps it with
+    // the group it belongs to when filtering rebuilds the list
     return html`
-      <knx-sticky-expansion-panel
-        .expanded=${this._expandedGroups.has(group.main)}
-        data-group=${group.main}
-        @expanded-changed=${this._groupPanelToggled}
-      >
+      <knx-sticky-expansion-panel>
         ${this._renderGroupHeader(group, true)}
         <div class="expanded-grid">${group.items.map((item) => this._renderEntry(item))}</div>
       </knx-sticky-expansion-panel>
     `;
-  }
-
-  private _groupPanelToggled(ev: CustomEvent<{ expanded: boolean }>): void {
-    const groupKey = Number((ev.currentTarget as HTMLElement).dataset.group);
-    const expanded = new Set(this._expandedGroups);
-    if (ev.detail.expanded) {
-      expanded.add(groupKey);
-    } else {
-      expanded.delete(groupKey);
-    }
-    this._expandedGroups = expanded;
   }
 
   private _searchLabel(count: number): string {
@@ -255,10 +241,13 @@ export class KnxDptReference extends LitElement {
                   >No datapoint types match the current search.</ha-alert
                 >`
               : nothing}
-            ${groupedEntries.map((group) =>
-              shouldRenderDptGroupAsCards(group)
-                ? this._renderNoCollapseGroup(group)
-                : this._renderExpandableGroup(group),
+            ${repeat(
+              groupedEntries,
+              (group) => group.main,
+              (group) =>
+                shouldRenderDptGroupAsCards(group)
+                  ? this._renderNoCollapseGroup(group)
+                  : this._renderExpandableGroup(group),
             )}
           </div>
         </div>

--- a/src/views/project_view.ts
+++ b/src/views/project_view.ts
@@ -856,6 +856,11 @@ export class KNXProjectView extends LitElement {
       flex: 1;
       min-height: 0;
       overflow-y: auto;
+      /* establish a stacking context so the sticky device headers (z-index: 2)
+         stay contained here; otherwise an ancestor paints them above this
+         scroller and they hide the overlay scrollbar, which has no layout
+         width of its own and floats over the cards' right edge */
+      isolation: isolate;
     }
 
     /* mirrors the .table-header of hass-tabs-subpage-data-table */


### PR DESCRIPTION
Follow-up to #406, which put `knx-sticky-expansion-panel` to work in the DPT reference view. Using it in two places surfaced a few rough edges; this smooths them out and fixes an unrelated scrollbar bug on the Devices tab found along the way.

## The panel

**Keep the divider and collapsed cards in place.** The header divider is drawn as a `box-shadow` rather than a `border-bottom`: a border stacked with the card's own bottom border into a visible 2px line once a scrolled card pushed its sticky header onto that edge. A shadow takes no layout space, and the card's `overflow: clip` removes it at exactly that point.

Collapsing a card that was scrolled into used to leave its top above the scrollport, so the header vanished and the cards below jumped up. The card now pulls the scroll offset back by the overshoot, landing the header at the top edge where the reader left it.

**Let it toggle itself.** The panel was controlled-only: `expanded-changed` was a *request* and the parent had to own `expanded`, so every consumer wired up state just to open a panel. The docstring credited that for avoiding `ha-expansion-panel`'s stale inline heights, but the two are unrelated — dropping the height animation is what avoids them.

It now follows `ha-expansion-panel`'s contract instead: toggle on click, fire `expanded-will-change` / `expanded-changed` as notifications, and skip the self-toggle when the event is already `defaultPrevented`, so a parent that owns the state can still take over from the capture phase.

**Animate expand and collapse.** Since being controlled was never what avoided the stale heights, the animation can come back — just not as a height. `ha-expansion-panel` measures the content once and writes an inline height, which goes stale when nested panels or dynamic content resize it afterwards. Animating an `0fr`/`1fr` grid track has no such problem: the browser keeps deriving the track size, so a card can grow mid-animation and still land right.

Content stays rendered for the length of the collapse and is unmounted on `transitionend` — guarded on the property name and the target, since a nested `ha-expansion-panel` animates its height inside this very card and those events bubble here too. A card hidden by a filter mid-collapse never gets a `transitionend` at all, so a timer unmounts it as a fallback.

Anchoring now runs as the collapse *starts*. The overshoot does not depend on the card's height, so applying it up front puts the card top at the scrollport edge while content is still at full height; the shrinking that follows moves nothing, which avoids chasing the scroll offset for every frame.

**Lift the header while it covers content.** A pinned header sat flat on the rows scrolling underneath it. It now casts a shadow, but only while it actually holds position over content — a card resting at its natural place has nothing to lift away from, and neither has a collapsed one. CSS cannot tell the difference on its own (there is no `:stuck`, and scroll-driven animations are not broadly supported yet), so a sentinel at the card's top edge is watched against the scroll container. Leaving upwards means pinned; leaving downwards only means the card is below the fold, which must not light up every card underneath.

The observer is re-attached on connect, not just on first render: a keyed list moves its items rather than rebuilding them, and a move is a disconnect plus a connect.

## The views

**Devices tab overlay scrollbar.** The device cards' sticky headers are `z-index: 2`, and neither the scroller — the `knx-project-devices-view` host — nor anything between it and those headers established a stacking context. They resolved their `z-index` against an ancestor stacking context *above* the scroller and painted over its overlay scrollbar, which has no layout width of its own and floats over the cards' right edge. Isolating the scroller contains them. Same fix as `.list-content` in #406, on the element that is the scroller here.

**DPT reference** drops the state that only echoed `expanded-changed` back; the group list is keyed so expansion follows a group when filtering reorders it.

**The devices view** keeps control — its expansion is derived from the active filters and driven by expand/collapse all — and its existing capture-phase interceptor now covers the device panels too, via the `id="summary"` the panel grew.

## Testing

Verified manually against a live instance on both `/knx/project` and `/knx/dpt_reference`: expansion, expand/collapse all, filtering and reordering, and the sticky/scroll behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)