### PR TITLE
Add resolution to complex field schema

### DIFF
--- a/src/components/knx-payload-selector.ts
+++ b/src/components/knx-payload-selector.ts
@@ -297,12 +297,13 @@ export class KnxPayloadSelector extends LitElement {
 
   private _fieldToKnxHaSelector(field: DPTComplexFieldSchema): KnxHaSelector {
     if (field.type === "integer" || field.type === "float") {
+      const step = field.resolution ?? (field.type === "float" ? 0.01 : 1);
       return this._knxHaSelector(field, {
         number: {
           mode: "box",
           min: field.value_min,
           max: field.value_max,
-          step: field.type === "float" ? 0.01 : 1,
+          step,
         },
       });
     }

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -24,6 +24,7 @@ export interface DPTComplexFieldSchema {
   options?: string[];
   value_min?: number;
   value_max?: number;
+  resolution?: number;
 }
 
 export interface DPTMetadata {

--- a/src/views/dpt_reference.ts
+++ b/src/views/dpt_reference.ts
@@ -145,6 +145,9 @@ export class KnxDptReference extends LitElement {
                   if (field.value_max != null) {
                     details.push(`max: ${field.value_max}`);
                   }
+                  if (field.resolution != null) {
+                    details.push(`resolution: ${field.resolution}`);
+                  }
                   if (field.options?.length) {
                     const pythonList = `[${field.options.map((opt) => this._pythonRepr(opt)).join(", ")}]`;
                     details.push(html`options: <code>${pythonList}</code>`);


### PR DESCRIPTION
This pull request introduces support for a new `resolution` property in the KNX DPT (Data Point Type) field schema, allowing for more precise control over numeric field increments. The changes ensure that the UI and internal logic now respect this property when present, and display it in the DPT reference view.

**Support for numeric field resolution:**

* Added an optional `resolution` property to the `DPTComplexFieldSchema` interface in `src/types/websocket.ts` to specify the step size for numeric fields.
* Updated the `_fieldToKnxHaSelector` method in `KnxPayloadSelector` to use the `resolution` value as the step for numeric selectors, defaulting to `0.01` for floats and `1` for integers if not provided.

**UI improvements:**

* Modified the DPT reference view in `KnxDptReference` to display the `resolution` property when present, providing clearer field details to users.