### PR TITLE
Keep entity create and edit flows to a single history entry

### DIFF
--- a/src/utils/navigation.test.ts
+++ b/src/utils/navigation.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { exitFlow, navigateInFlow } from "./navigation";
+
+const navigateMock = vi.hoisted(() => vi.fn(() => Promise.resolve(true)));
+vi.mock("@ha/common/navigate", () => ({ navigate: navigateMock }));
+
+/** Minimal `mainWindow` stub - jsdom doesn't allow manipulating `history.length`. */
+const fakeMainWindow = vi.hoisted(() => {
+  const target = new EventTarget();
+  return {
+    history: {
+      length: 1,
+      back: vi.fn(),
+    },
+    setTimeout: (...args: Parameters<typeof setTimeout>) => setTimeout(...args),
+    clearTimeout: (handle?: any) => clearTimeout(handle),
+    addEventListener: target.addEventListener.bind(target),
+    removeEventListener: target.removeEventListener.bind(target),
+    dispatchEvent: target.dispatchEvent.bind(target),
+  };
+});
+vi.mock("@ha/common/dom/get_main_window", () => ({ mainWindow: fakeMainWindow }));
+
+describe("navigateInFlow", () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+  });
+
+  it("replaces the current history entry", () => {
+    navigateInFlow("/knx/entities/create/switch");
+    expect(navigateMock).toHaveBeenCalledWith("/knx/entities/create/switch", { replace: true });
+  });
+});
+
+describe("exitFlow", () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+    fakeMainWindow.history.back.mockClear();
+    fakeMainWindow.history.length = 1;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("goes back to the page the flow was entered from", async () => {
+    fakeMainWindow.history.length = 3;
+    fakeMainWindow.history.back.mockImplementation(() => {
+      fakeMainWindow.dispatchEvent(new Event("popstate"));
+    });
+
+    await exitFlow("/knx/entities");
+
+    expect(fakeMainWindow.history.back).toHaveBeenCalledOnce();
+    // no new history entry is created when leaving the flow
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("navigates to the fallback path when there is no history to go back to", async () => {
+    // eg. the flow was opened directly by URL
+    await exitFlow("/knx/entities");
+
+    expect(fakeMainWindow.history.back).not.toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith("/knx/entities", { replace: true });
+  });
+
+  it("resolves when no popstate is fired for the traversal", async () => {
+    vi.useFakeTimers();
+    fakeMainWindow.history.length = 3;
+    fakeMainWindow.history.back.mockImplementation(() => undefined);
+
+    const exited = exitFlow("/knx/entities");
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await expect(exited).resolves.toBeUndefined();
+  });
+});

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,43 @@
+import { mainWindow } from "@ha/common/dom/get_main_window";
+import { navigate } from "@ha/common/navigate";
+
+/**
+ * Navigation helpers for sub-page flows - eg. creating or editing an entity.
+ *
+ * A flow is entered by a regular `navigate()` (pushing one history entry), moves
+ * between its steps by replacing that entry and is left again by `exitFlow()`,
+ * which drops it. This way a finished flow leaves no trace in the browser
+ * history - `back` from a list view leads to where the user came from and not
+ * through every flow visited before.
+ */
+
+// safety net in case `popstate` is not fired for the requested traversal
+const HISTORY_TRAVERSAL_TIMEOUT = 500;
+
+/** Navigate between the steps of a flow, without adding a history entry. */
+export const navigateInFlow = (path: string): Promise<boolean> => navigate(path, { replace: true });
+
+/**
+ * Leave a flow by going back to the page it was entered from, dropping the
+ * history entry of the flow. When there is no history to go back to - eg. the
+ * flow was opened directly by URL - `fallbackPath` is navigated to instead.
+ *
+ * Resolves when the navigation was applied, so dialogs - which push their own
+ * history state - can safely be opened afterwards.
+ */
+export const exitFlow = async (fallbackPath: string): Promise<void> => {
+  if (mainWindow.history.length <= 1) {
+    await navigate(fallbackPath, { replace: true });
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const finish = () => {
+      mainWindow.clearTimeout(timeout);
+      mainWindow.removeEventListener("popstate", finish);
+      resolve();
+    };
+    const timeout = mainWindow.setTimeout(finish, HISTORY_TRAVERSAL_TIMEOUT);
+    mainWindow.addEventListener("popstate", finish);
+    mainWindow.history.back();
+  });
+};

--- a/src/views/entities_create.ts
+++ b/src/views/entities_create.ts
@@ -16,6 +16,7 @@ import "@ha/components/ha-yaml-editor";
 import type { HaYamlEditor } from "@ha/components/ha-yaml-editor";
 import "@ha/panels/config/components/ha-config-navigation-list";
 import { navigate } from "@ha/common/navigate";
+import { isNavigationClick } from "@ha/common/dom/is-navigation-click";
 import { mainWindow } from "@ha/common/dom/get_main_window";
 import { fireEvent } from "@ha/common/dom/fire_event";
 import { throttle } from "@ha/common/util/throttle";
@@ -43,6 +44,7 @@ import { entitiesByGroupContext } from "../data/knx-entities-by-group-context";
 import type { EntitiesByGroupContextValue } from "../data/knx-entities-by-group-context";
 import { getPlatformStyle } from "../utils/common";
 import { validDPTsForSchema } from "../utils/dpt";
+import { exitFlow, navigateInFlow } from "../utils/navigation";
 import { dragDropContext, DragDropContext } from "../utils/drag-drop-context";
 import { KNXLogger } from "../tools/knx-logger";
 import type { KNX } from "../types/knx";
@@ -218,7 +220,7 @@ export class KNXCreateEntity extends LitElement {
       <hass-subpage
         .hass=${this.hass}
         .narrow=${this.narrow!}
-        .back-path=${this.backPath}
+        .backPath=${this.backPath}
         .header=${this.hass.localize("ui.panel.config.integrations.config_flow.error")}
       >
         <div class="content">
@@ -233,10 +235,11 @@ export class KNXCreateEntity extends LitElement {
       <hass-subpage
         .hass=${this.hass}
         .narrow=${this.narrow!}
-        .back-path=${this.backPath}
+        .backPath=${this.backPath}
+        .backCallback=${this._exitEntitiesFlow}
         .header=${this.hass.localize("component.knx.config_panel.entities.create.title")}
       >
-        <div class="type-selection">
+        <div class="type-selection" @click=${this._typeSelected}>
           <ha-card
             outlined
             .header=${this.hass.localize(
@@ -268,6 +271,22 @@ export class KNXCreateEntity extends LitElement {
     `;
   }
 
+  private _typeSelected(ev: MouseEvent) {
+    // The type selection items are links - handle plain clicks here to replace the current
+    // history entry instead of pushing a new one. Modifier clicks open a new tab as usual.
+    const href = isNavigationClick(ev);
+    if (!href) return;
+    navigateInFlow(href);
+  }
+
+  private _backToTypeSelection = () => {
+    navigateInFlow("/knx/entities/create");
+  };
+
+  private _exitEntitiesFlow = () => {
+    exitFlow("/knx/entities");
+  };
+
   private _renderEntityConfig(platform: SupportedPlatform): TemplateResult {
     const create = this._intent === "create";
     const schema = this.knx.schema[platform]!;
@@ -275,7 +294,8 @@ export class KNXCreateEntity extends LitElement {
     return html`<hass-subpage
       .hass=${this.hass}
       .narrow=${this.narrow!}
-      .back-path=${this.backPath}
+      .backPath=${this.backPath}
+      .backCallback=${create ? this._backToTypeSelection : this._exitEntitiesFlow}
       .scrollable=${this._mode === "gui"}
       .header=${create
         ? this.hass.localize("component.knx.config_panel.entities.create.title")
@@ -436,11 +456,12 @@ export class KNXCreateEntity extends LitElement {
       return;
     }
     createEntity(this.hass, { platform: this.entityPlatform, data: this._config })
-      .then((createEntityResult) => {
+      .then(async (createEntityResult) => {
         if (this._handleValidationError(createEntityResult, true)) return;
         logger.debug("Successfully created entity", createEntityResult.entity_id);
         this._entitiesByGroupContext?.reload();
-        navigate("/knx/entities", { replace: true });
+        // await leaving the flow before opening the dialog - it pushes its own history state
+        await exitFlow("/knx/entities");
         if (!createEntityResult.entity_id) {
           logger.error("entity_id not found after creation.");
           return;
@@ -472,7 +493,7 @@ export class KNXCreateEntity extends LitElement {
         if (this._handleValidationError(createEntityResult, true)) return;
         logger.debug("Successfully updated entity", this.entityId);
         this._entitiesByGroupContext?.reload();
-        navigate("/knx/entities", { replace: true });
+        exitFlow("/knx/entities");
       })
       .catch((err) => {
         logger.error("Error updating entity", err);

--- a/src/views/expose_create.ts
+++ b/src/views/expose_create.ts
@@ -47,6 +47,7 @@ import {
 } from "../data/knx-expose-groups-context";
 import type { KnxHaSelector, GASelectorOptions } from "../types/schema";
 import { setNestedValue } from "../utils/config-helper";
+import { exitFlow, navigateInFlow } from "../utils/navigation";
 import { extractValidationErrors, getValidationError } from "../utils/validation";
 
 import { knxProjectContext } from "../data/knx-project-context";
@@ -257,7 +258,7 @@ export class KNXCreateExpose extends LitElement {
       <hass-subpage
         .hass=${this.hass}
         .narrow=${this.narrow}
-        .backPath=${"/knx/expose/view"}
+        .backCallback=${this._exitExposeFlow}
         .header=${this.hass.localize("component.knx.config_panel.expose.create.title")}
       >
         <div class="content">
@@ -292,13 +293,13 @@ export class KNXCreateExpose extends LitElement {
 
   private _renderConfig(): TemplateResult {
     const create = this._intent === "create";
-    const backPath = create ? "/knx/expose/create" : this.backPath;
 
     return html`
       <hass-subpage
         .hass=${this.hass}
         .narrow=${this.narrow}
-        .backPath=${backPath}
+        .backPath=${this.backPath}
+        .backCallback=${create ? this._backToEntityPicker : this._exitExposeFlow}
         .scrollable=${this._mode === "gui"}
         .header=${create
           ? this.hass.localize("component.knx.config_panel.expose.create.title")
@@ -702,9 +703,18 @@ export class KNXCreateExpose extends LitElement {
   private _entityChanged(ev: CustomEvent) {
     const entityId = (ev.detail.value as string) || undefined;
     if (entityId) {
-      navigate(`/knx/expose/create/${entityId}${mainWindow.location.search}`);
+      // stay in the same history entry - the create flow is left by `exitFlow`
+      navigateInFlow(`/knx/expose/create/${entityId}${mainWindow.location.search}`);
     }
   }
+
+  private _backToEntityPicker = () => {
+    navigateInFlow(`/knx/expose/create${mainWindow.location.search}`);
+  };
+
+  private _exitExposeFlow = () => {
+    exitFlow("/knx/expose");
+  };
 
   private _addExpose() {
     this._config = { ...this._config, options: [...this._config.options, { ga: {} }] };
@@ -773,7 +783,7 @@ export class KNXCreateExpose extends LitElement {
       if (this._handleResult(result, true)) return;
       logger.debug("Successfully saved expose", this._entityId);
       this._exposeGroupsCtx?.reload();
-      navigate("/knx/expose", { replace: true });
+      await exitFlow("/knx/expose");
     } catch (err) {
       logger.error("Error saving expose", err);
       navigate("/knx/error", { replace: true, data: err });


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/175226

## The problem

Creating an entity pushed two history entries — `/knx/entities/create` (type selection) and `/knx/entities/create/<platform>` (config page) — while saving only *replaced* the last one with `/knx/entities`. So every created entity left a `create` and an `entities` entry behind, and navigating back walked through the whole create flow again, once per created entity. Reported from the Android app, where the sidebar isn't reachable by a swipe and back is the only way out.

The expose create flow had the same pattern, plus a back button that *added* a history entry (`backPath` renders a link).

## What changed

A flow now occupies exactly one history entry: pushed when entered, replaced between its steps, dropped when left.

New `src/utils/navigation.ts`:

- `navigateInFlow(path)` — moves between the steps of a flow by replacing the current entry.
- `exitFlow(fallbackPath)` — leaves a flow with `history.back()` instead of adding an entry; falls back to a replacing navigation when there is nothing to go back to (flow opened directly by URL). It resolves after the traversal was applied, so the more-info dialog opened after creating an entity — which pushes its own history state — cannot race it.

`entities_create.ts`:

- The type selection items are links, so their clicks are intercepted (`isNavigationClick`) and re-issued as replacing navigations; modifier clicks still open a new tab. This also keeps the navigation in the SPA context, which matters because the panel renders in an iframe.
- Back arrow: config page → type selection (create) or out of the flow (edit); type selection → out of the flow.
- Create and update leave via `exitFlow("/knx/entities")`.

`expose_create.ts`: same treatment for entity picker → config → save.

Fixed four `.back-path=` / hardcoded `backPath` bindings on the way — `hass-subpage`'s property is `backPath`, so `.back-path=` only ever set a dead expando (lit-analyzer warnings drop from 6 to 3 in these two files).

## Behaviour changes worth reviewing

- Browser back on the config page now leaves the flow instead of going to the type selection; the in-page back arrow still goes to the type selection.
- After saving, the user returns to the page the flow was entered from. That is the list view in the usual case, but e.g. the project view when the flow was started from its "create sensor" menu item — previously it always ended on the entity list.

## Testing

- New unit tests for `exitFlow` / `navigateInFlow` (back path, fallback path, timeout safety net); full suite passes.
- Verified against a local HA instance: add → `history.length` 2→3, picking a platform keeps it at 3 (was 4), back arrow returns to the type selection without growing history, and `exitFlow` genuinely traverses back — the flow entry becomes a *forward* entry rather than stacking up. The post-save path was not exercised end-to-end against a live backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)