### PR TITLE
Warn about unsaved changes when leaving an editor

### DIFF
--- a/src/mixins/prevent-unsaved-mixin.ts
+++ b/src/mixins/prevent-unsaved-mixin.ts
@@ -1,0 +1,84 @@
+import type { LitElement, PropertyValues } from "lit";
+
+import { isNavigationClick } from "@ha/common/dom/is-navigation-click";
+import { mainWindow } from "@ha/common/dom/get_main_window";
+import type { Constructor } from "@ha/types";
+
+/**
+ * Variant of HAs `PreventUnsavedMixin` that guards the panel window and
+ * `mainWindow`.
+ *
+ * The KNX panel is rendered in an iframe, and events don't cross that boundary:
+ * clicks on HAs sidebar or toolbar never reach the panels `window`, while
+ * clicks inside the panel never reach `mainWindow`. Listening on both is needed
+ * to catch every way out of an editor holding unsaved changes.
+ *
+ * Only link clicks and unloading the page are covered - navigating back is not,
+ * so callers have to await `promptDiscardChanges()` in their own back handlers.
+ *
+ * Use together with HAs `DirtyStateProviderMixin`, which provides `isDirtyState`.
+ */
+export const PreventUnsavedMixin = <T extends Constructor<LitElement>>(superClass: T) =>
+  class extends superClass {
+    private _guardedWindows: Window[] = mainWindow === window ? [window] : [window, mainWindow];
+
+    private _handleClick = async (ev: MouseEvent) => {
+      // resolve the target before awaiting - afterwards the composed path is empty
+      const target = ev.composedPath()[0];
+      if (!isNavigationClick(ev)) {
+        return;
+      }
+      // `isNavigationClick` prevented the default - the click is replayed when confirmed
+      if (!(await this.promptDiscardChanges())) {
+        return;
+      }
+      this._removeListeners();
+      target?.dispatchEvent(new MouseEvent(ev.type, ev));
+    };
+
+    private _handleUnload = (ev: BeforeUnloadEvent) => ev.preventDefault();
+
+    private _addListeners() {
+      // adding the same listener twice is a no-op, so this can run on every update
+      for (const win of this._guardedWindows) {
+        win.addEventListener("click", this._handleClick, true);
+        win.addEventListener("beforeunload", this._handleUnload);
+      }
+    }
+
+    private _removeListeners() {
+      for (const win of this._guardedWindows) {
+        win.removeEventListener("click", this._handleClick, true);
+        win.removeEventListener("beforeunload", this._handleUnload);
+      }
+    }
+
+    protected willUpdate(changedProperties: PropertyValues<this>): void {
+      super.willUpdate(changedProperties);
+
+      if (this.hasUnsavedChanges()) {
+        this._addListeners();
+      } else {
+        this._removeListeners();
+      }
+    }
+
+    public disconnectedCallback(): void {
+      super.disconnectedCallback();
+
+      this._removeListeners();
+    }
+
+    /**
+     * Override to report pending changes - typically `isDirtyState` of
+     * `DirtyStateProviderMixin`, plus editor input that never reached the config.
+     */
+    protected hasUnsavedChanges(): boolean {
+      return false;
+    }
+
+    /** Override to ask the user. Return `true` to leave, `false` to stay. */
+    protected async promptDiscardChanges(): Promise<boolean> {
+      return true;
+    }
+  };

--- a/src/utils/navigation.test.ts
+++ b/src/utils/navigation.test.ts
@@ -11,6 +11,7 @@ const fakeMainWindow = vi.hoisted(() => {
   return {
     history: {
       length: 1,
+      state: null as { dialog?: string } | null,
       back: vi.fn(),
     },
     setTimeout: (...args: Parameters<typeof setTimeout>) => setTimeout(...args),
@@ -38,6 +39,7 @@ describe("exitFlow", () => {
     navigateMock.mockClear();
     fakeMainWindow.history.back.mockClear();
     fakeMainWindow.history.length = 1;
+    fakeMainWindow.history.state = null;
   });
 
   afterEach(() => {
@@ -63,6 +65,29 @@ describe("exitFlow", () => {
 
     expect(fakeMainWindow.history.back).not.toHaveBeenCalled();
     expect(navigateMock).toHaveBeenCalledWith("/knx/entities", { replace: true });
+  });
+
+  it("waits for an open dialog to drop its history entry before going back", async () => {
+    // a dialog - eg. the unsaved changes confirmation - removes its own entry when closed
+    fakeMainWindow.history.length = 3;
+    fakeMainWindow.history.state = { dialog: "dialog-box" };
+    fakeMainWindow.history.back.mockImplementation(() => {
+      fakeMainWindow.dispatchEvent(new Event("popstate"));
+    });
+
+    const exited = exitFlow("/knx/entities");
+    await new Promise((resolve) => {
+      setTimeout(resolve);
+    });
+    // still waiting for the dialog - going back now would only close it
+    expect(fakeMainWindow.history.back).not.toHaveBeenCalled();
+
+    // the dialog dropped its entry
+    fakeMainWindow.history.state = null;
+    fakeMainWindow.dispatchEvent(new Event("popstate"));
+    await exited;
+
+    expect(fakeMainWindow.history.back).toHaveBeenCalledOnce();
   });
 
   it("resolves when no popstate is fired for the traversal", async () => {

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -11,8 +11,28 @@ import { navigate } from "@ha/common/navigate";
  * through every flow visited before.
  */
 
-// safety net in case `popstate` is not fired for the requested traversal
+// safety net in case `popstate` is not fired for an expected history change
 const HISTORY_TRAVERSAL_TIMEOUT = 500;
+
+/** Resolves on the next `popstate` of the main window - or when it doesn't come. */
+const _historyChanged = (): Promise<void> =>
+  new Promise<void>((resolve) => {
+    const finish = () => {
+      mainWindow.clearTimeout(timeout);
+      mainWindow.removeEventListener("popstate", finish);
+      resolve();
+    };
+    const timeout = mainWindow.setTimeout(finish, HISTORY_TRAVERSAL_TIMEOUT);
+    mainWindow.addEventListener("popstate", finish);
+  });
+
+/**
+ * Open dialogs push a history entry, which they remove again when closed - going
+ * back before that happened would only close the dialog. `navigate()` handles
+ * this itself, traversing the history has to wait for it.
+ */
+const _dialogHistorySettled = (): Promise<void> =>
+  mainWindow.history.state?.dialog ? _historyChanged() : Promise.resolve();
 
 /** Navigate between the steps of a flow, without adding a history entry. */
 export const navigateInFlow = (path: string): Promise<boolean> => navigate(path, { replace: true });
@@ -26,18 +46,13 @@ export const navigateInFlow = (path: string): Promise<boolean> => navigate(path,
  * history state - can safely be opened afterwards.
  */
 export const exitFlow = async (fallbackPath: string): Promise<void> => {
+  // eg. when leaving was confirmed in a dialog - it still has to drop its entry
+  await _dialogHistorySettled();
   if (mainWindow.history.length <= 1) {
     await navigate(fallbackPath, { replace: true });
     return;
   }
-  await new Promise<void>((resolve) => {
-    const finish = () => {
-      mainWindow.clearTimeout(timeout);
-      mainWindow.removeEventListener("popstate", finish);
-      resolve();
-    };
-    const timeout = mainWindow.setTimeout(finish, HISTORY_TRAVERSAL_TIMEOUT);
-    mainWindow.addEventListener("popstate", finish);
-    mainWindow.history.back();
-  });
+  const changed = _historyChanged();
+  mainWindow.history.back();
+  await changed;
 };

--- a/src/views/entities_create.ts
+++ b/src/views/entities_create.ts
@@ -1,4 +1,5 @@
 import { mdiPlus, mdiFloppy, mdiPlaylistEdit } from "@mdi/js";
+import deepClone from "deep-clone-simple";
 import type { TemplateResult, PropertyValues } from "lit";
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state, query } from "lit/decorators";
@@ -21,6 +22,7 @@ import { mainWindow } from "@ha/common/dom/get_main_window";
 import { fireEvent } from "@ha/common/dom/fire_event";
 import { throttle } from "@ha/common/util/throttle";
 import { showConfirmationDialog } from "@ha/dialogs/generic/show-dialog-box";
+import { DirtyStateProviderMixin } from "@ha/mixins/dirty-state-provider-mixin";
 import type { HomeAssistant, Route } from "@ha/types";
 
 import "../components/knx-configure-entity";
@@ -43,8 +45,10 @@ import { knxProjectContext } from "../data/knx-project-context";
 import { entitiesByGroupContext } from "../data/knx-entities-by-group-context";
 import type { EntitiesByGroupContextValue } from "../data/knx-entities-by-group-context";
 import { getPlatformStyle } from "../utils/common";
+import { setNestedValue } from "../utils/config-helper";
 import { validDPTsForSchema } from "../utils/dpt";
 import { exitFlow, navigateInFlow } from "../utils/navigation";
+import { PreventUnsavedMixin } from "../mixins/prevent-unsaved-mixin";
 import { dragDropContext, DragDropContext } from "../utils/drag-drop-context";
 import { KNXLogger } from "../tools/knx-logger";
 import type { KNX } from "../types/knx";
@@ -53,7 +57,9 @@ import type { KNXProject } from "../types/websocket";
 const logger = new KNXLogger("knx-create-entity");
 
 @customElement("knx-create-entity")
-export class KNXCreateEntity extends LitElement {
+export class KNXCreateEntity extends DirtyStateProviderMixin<EntityData>()(
+  PreventUnsavedMixin(LitElement),
+) {
   @property({ type: Object }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public knx!: KNX;
@@ -106,9 +112,27 @@ export class KNXCreateEntity extends LitElement {
       if (!entityId) return;
       const { platform, data } = await getEntityConfig(this.hass, entityId);
       this.entityPlatform = platform;
-      this._config = data;
+      // `knx-configure-entity` edits the config in place, so dirty state tracking needs its
+      // own copy to compare against. Cloning also moves the config into this realm - the
+      // panel runs in an iframe and `deepEqual` compares constructors, which differ there.
+      this._config = deepClone(data);
+      this._initDirtyTracking({ type: "deep" }, deepClone(data));
     },
   });
+
+  /**
+   * The config a new entity starts out with - `knx-configure-entity` applies url
+   * parameters the same way, eg. when creating an entity from the project view,
+   * so an untouched form doesn't count as changed.
+   */
+  private _newEntityConfig(): EntityData {
+    const config = { entity: {}, knx: {} } as EntityData;
+    const urlParams = new URLSearchParams(mainWindow.location.search);
+    for (const [path, value] of urlParams.entries()) {
+      setNestedValue(config, path, value, logger);
+    }
+    return config;
+  }
 
   private _dragDropContextProvider = new ContextProvider(this, {
     context: dragDropContext,
@@ -118,6 +142,7 @@ export class KNXCreateEntity extends LitElement {
   });
 
   protected willUpdate(changedProperties: PropertyValues<this>) {
+    super.willUpdate(changedProperties); // dirty state listeners are handled by the mixin
     if (changedProperties.has("route")) {
       const intent = this.route.prefix.split("/").at(-1);
       if (intent === "create" || intent === "edit") {
@@ -139,10 +164,12 @@ export class KNXCreateEntity extends LitElement {
         // knx/entities/create/light -> path: "/light"
         this.entityId = undefined; // clear entityId for create intent
         this.entityPlatform = this.route.path.split("/")[1];
+        this._initDirtyTracking({ type: "deep" }, this._newEntityConfig());
       } else if (intent === "edit") {
         // knx/entities/edit/light.living_room -> path: "/light.living_room"
         this.entityId = this.route.path.split("/")[1];
         // this.entityPlatform will be set from load task result - triggering the next load task
+        this._initDirtyTracking({ type: "deep" }); // baseline is set from the loaded config
       }
     }
   }
@@ -274,18 +301,36 @@ export class KNXCreateEntity extends LitElement {
   private _typeSelected(ev: MouseEvent) {
     // The type selection items are links - handle plain clicks here to replace the current
     // history entry instead of pushing a new one. Modifier clicks open a new tab as usual.
+    // Unsaved changes are guarded by `PreventUnsavedMixin` before this is reached.
     const href = isNavigationClick(ev);
     if (!href) return;
     navigateInFlow(href);
   }
 
-  private _backToTypeSelection = () => {
+  private _backToTypeSelection = async () => {
+    if (!(await this.promptDiscardChanges())) return;
     navigateInFlow("/knx/entities/create");
   };
 
-  private _exitEntitiesFlow = () => {
+  private _exitEntitiesFlow = async () => {
+    if (!(await this.promptDiscardChanges())) return;
     exitFlow("/knx/entities");
   };
+
+  protected override hasUnsavedChanges(): boolean {
+    // invalid yaml is not applied to the config, but is unsaved input nonetheless
+    return this.isDirtyState || !!this._yamlErrors;
+  }
+
+  protected override async promptDiscardChanges(): Promise<boolean> {
+    if (!this.hasUnsavedChanges()) return true;
+    return showConfirmationDialog(this, {
+      text: this.hass.localize("ui.panel.config.common.editor.confirm_unsaved"),
+      confirmText: this.hass.localize("ui.common.leave"),
+      dismissText: this.hass.localize("ui.common.stay"),
+      destructive: true,
+    });
+  }
 
   private _renderEntityConfig(platform: SupportedPlatform): TemplateResult {
     const create = this._intent === "create";
@@ -383,6 +428,8 @@ export class KNXCreateEntity extends LitElement {
     ev.stopPropagation();
     logger.debug("configChanged", ev.detail);
     this._config = ev.detail;
+    // `knx-configure-entity` edits the config in place, so track a snapshot of it
+    this._updateDirtyState(deepClone(this._config!));
     if (this._validationErrors) {
       this._entityValidate();
     }
@@ -412,6 +459,7 @@ export class KNXCreateEntity extends LitElement {
     }
     this._yamlErrors = undefined;
     this._config = ev.detail.value as EntityData;
+    this._updateDirtyState(this._config);
     if (this._validationErrors) {
       this._entityValidate();
     }
@@ -459,6 +507,7 @@ export class KNXCreateEntity extends LitElement {
       .then(async (createEntityResult) => {
         if (this._handleValidationError(createEntityResult, true)) return;
         logger.debug("Successfully created entity", createEntityResult.entity_id);
+        this._markDirtyStateClean();
         this._entitiesByGroupContext?.reload();
         // await leaving the flow before opening the dialog - it pushes its own history state
         await exitFlow("/knx/entities");
@@ -492,6 +541,7 @@ export class KNXCreateEntity extends LitElement {
       .then((createEntityResult) => {
         if (this._handleValidationError(createEntityResult, true)) return;
         logger.debug("Successfully updated entity", this.entityId);
+        this._markDirtyStateClean();
         this._entitiesByGroupContext?.reload();
         exitFlow("/knx/entities");
       })

--- a/src/views/expose_create.ts
+++ b/src/views/expose_create.ts
@@ -1,4 +1,5 @@
 import { mdiDelete, mdiFileDocumentEdit, mdiPlus, mdiFloppy, mdiPlaylistEdit } from "@mdi/js";
+import deepClone from "deep-clone-simple";
 import type { TemplateResult, PropertyValues } from "lit";
 import { LitElement, html, css, nothing } from "lit";
 import { consume } from "@lit/context";
@@ -28,6 +29,7 @@ import { mainWindow } from "@ha/common/dom/get_main_window";
 import { navigate } from "@ha/common/navigate";
 import { throttle } from "@ha/common/util/throttle";
 import { showConfirmationDialog } from "@ha/dialogs/generic/show-dialog-box";
+import { DirtyStateProviderMixin } from "@ha/mixins/dirty-state-provider-mixin";
 import type { HomeAssistant, Route } from "@ha/types";
 
 import "../components/knx-expose-template-preview";
@@ -48,6 +50,7 @@ import {
 import type { KnxHaSelector, GASelectorOptions } from "../types/schema";
 import { setNestedValue } from "../utils/config-helper";
 import { exitFlow, navigateInFlow } from "../utils/navigation";
+import { PreventUnsavedMixin } from "../mixins/prevent-unsaved-mixin";
 import { extractValidationErrors, getValidationError } from "../utils/validation";
 
 import { knxProjectContext } from "../data/knx-project-context";
@@ -117,7 +120,9 @@ const HIDDEN_ATTRIBUTES = new Set([
 ]);
 
 @customElement("knx-create-expose")
-export class KNXCreateExpose extends LitElement {
+export class KNXCreateExpose extends DirtyStateProviderMixin<ExposeConfigData>()(
+  PreventUnsavedMixin(LitElement),
+) {
   @property({ type: Object }) public hass!: HomeAssistant;
 
   @property({ attribute: false }) public knx!: KNX;
@@ -163,20 +168,24 @@ export class KNXCreateExpose extends LitElement {
     args: () => [this._entityId] as const,
     task: async ([entityId]) => {
       if (!entityId) return;
-      this._config = await getExposeConfig(this.hass, entityId);
+      // clone into this realm - the panel runs in an iframe, and the `deepEqual` used for
+      // dirty state tracking compares constructors, which differ between the two realms
+      this._config = deepClone(await getExposeConfig(this.hass, entityId));
 
       const urlParams = new URLSearchParams(mainWindow.location.search);
       const copyFrom = urlParams.get("copy");
       if (copyFrom && copyFrom !== entityId) {
         const copyConfig = await getExposeConfig(this.hass, copyFrom);
         logger.debug("Copying expose options from", copyFrom, copyConfig);
-        this._config = copyConfig;
+        this._config = deepClone(copyConfig);
       }
       if (this._config.options.length === 0) {
         this._config = { ...this._config, options: [{ ga: {} }] };
       }
       this._validationErrors = undefined;
       this._validationBaseError = undefined;
+      // the loaded config - or the one copied from another entity - is the clean state
+      this._initDirtyTracking({ type: "deep" }, deepClone(this._config));
     },
   });
 
@@ -184,6 +193,7 @@ export class KNXCreateExpose extends LitElement {
     this.hass.localize(`component.knx.config_panel.expose.create.${key}`);
 
   protected willUpdate(changedProperties: PropertyValues<this>) {
+    super.willUpdate(changedProperties); // unsaved changes listeners are handled by the mixin
     if (changedProperties.has("route")) {
       const intent = this.route.prefix.split("/").slice(-1)[0];
       if (intent === "create" || intent === "edit") {
@@ -200,6 +210,8 @@ export class KNXCreateExpose extends LitElement {
       if (entityId !== this._entityId) {
         this._entityId = entityId;
         this._config = { options: [{ ga: {} }] };
+        // reset tracking - the load task sets the baseline once the config is known
+        this._initDirtyTracking({ type: "deep" }, deepClone(this._config));
         this._validationErrors = undefined;
         this._validationBaseError = undefined;
         this._mode = "gui";
@@ -483,7 +495,7 @@ export class KNXCreateExpose extends LitElement {
       return;
     }
     this._yamlErrors = undefined;
-    this._config = ev.detail.value as ExposeConfigData;
+    this._setConfig(ev.detail.value as ExposeConfigData);
     if (this._validationErrors) {
       this._validate();
     }
@@ -543,7 +555,7 @@ export class KNXCreateExpose extends LitElement {
     const value = textarea?.value ?? "";
     const config = { ...this._config };
     setNestedValue(config, "notes", value || undefined, logger);
-    this._config = config as ExposeConfigData;
+    this._setConfig(config as ExposeConfigData);
   }
 
   private _openNotesDialog() {
@@ -708,23 +720,45 @@ export class KNXCreateExpose extends LitElement {
     }
   }
 
-  private _backToEntityPicker = () => {
+  private _backToEntityPicker = async () => {
+    if (!(await this.promptDiscardChanges())) return;
     navigateInFlow(`/knx/expose/create${mainWindow.location.search}`);
   };
 
-  private _exitExposeFlow = () => {
+  private _exitExposeFlow = async () => {
+    if (!(await this.promptDiscardChanges())) return;
     exitFlow("/knx/expose");
   };
 
+  private _setConfig(config: ExposeConfigData) {
+    this._config = config;
+    this._updateDirtyState(config);
+  }
+
+  protected override hasUnsavedChanges(): boolean {
+    // invalid yaml is not applied to the config, but is unsaved input nonetheless
+    return this.isDirtyState || !!this._yamlErrors;
+  }
+
+  protected override async promptDiscardChanges(): Promise<boolean> {
+    if (!this.hasUnsavedChanges()) return true;
+    return showConfirmationDialog(this, {
+      text: this.hass.localize("ui.panel.config.common.editor.confirm_unsaved"),
+      confirmText: this.hass.localize("ui.common.leave"),
+      dismissText: this.hass.localize("ui.common.stay"),
+      destructive: true,
+    });
+  }
+
   private _addExpose() {
-    this._config = { ...this._config, options: [...this._config.options, { ga: {} }] };
+    this._setConfig({ ...this._config, options: [...this._config.options, { ga: {} }] });
   }
 
   private _removeExpose(ev: Event) {
     ev.preventDefault();
     ev.stopPropagation();
     const idx = parseInt((ev.currentTarget as HTMLElement).dataset.idx ?? "0");
-    this._config = { ...this._config, options: this._config.options.filter((_, i) => i !== idx) };
+    this._setConfig({ ...this._config, options: this._config.options.filter((_, i) => i !== idx) });
     if (this._validationErrors) this._validate();
   }
 
@@ -759,7 +793,7 @@ export class KNXCreateExpose extends LitElement {
     }
     setNestedValue(nextItem, key, value, logger);
     newOptions[idx] = nextItem as ExposeOption;
-    this._config = { ...this._config, options: newOptions };
+    this._setConfig({ ...this._config, options: newOptions });
     logger.debug("Updated expose item", idx, key, value, "new config:", this._config);
     if (this._validationErrors) this._validate();
   }
@@ -782,6 +816,7 @@ export class KNXCreateExpose extends LitElement {
       const result = await updateExpose(this.hass, this._entityId, this._config);
       if (this._handleResult(result, true)) return;
       logger.debug("Successfully saved expose", this._entityId);
+      this._markDirtyStateClean();
       this._exposeGroupsCtx?.reload();
       await exitFlow("/knx/expose");
     } catch (err) {


### PR DESCRIPTION
Follow-up to #423. Leaving the entity or expose editor with unsaved changes discarded them silently.

## What changed

Both editors now use HA's `DirtyStateProviderMixin` for change tracking, plus a local `PreventUnsavedMixin` in `src/mixins/`.

HA's own `PreventUnsavedMixin` only listens on `window`, which doesn't work for this panel: it renders in an iframe, so clicks on HA's sidebar never reach the panel's `window`, and clicks inside the panel never reach `mainWindow`. The local variant guards both. It also drops the `isDirtyState` declaration in favour of a `hasUnsavedChanges()` hook, so the editors can fold in state that never reaches the config (invalid YAML).

Coverage: link clicks (inside the panel and in HA's chrome), unloading the page, and the editors' own back buttons, which navigate programmatically and await the prompt themselves. **Navigating back in the browser is not covered** — same as HA's automation, script and scene editors; guarding it needs a sentinel history entry, which seemed disproportionate here.

The prompt reuses `ui.panel.config.common.editor.confirm_unsaved` with `ui.common.leave` / `ui.common.stay`, so no new strings.

## Three bugs found while testing this

1. **Everything was dirty on arrival.** `deepEqual` compares constructors, and configs from `hass.callWS` are created in the main window's realm, so a locally cloned baseline never compared equal. Loaded configs are now cloned into the panel's realm.
2. **Changes were never detected in the entity editor.** `knx-configure-entity` edits the config object in place, so the baseline — which held the same reference — was edited along with it. The baseline now gets its own copy.
3. **Confirming "leave" didn't leave.** Dialogs push a history entry and remove it when closed, so `exitFlow`'s `history.back()` only popped the dialog's entry and stayed on the page. `exitFlow` now waits for the dialog to drop its entry first (HA's `navigate()` does the same internally, which is why the type-selection back button was unaffected).

## Testing

Unit test for the new `exitFlow` wait; full suite passes.

Verified against a local HA instance, entity and expose editors:

- untouched editor → back button leaves immediately, no prompt
- edited → back button prompts; "Stay" stays, "Leave" navigates back to the list
- edited → click in HA's sidebar prompts and blocks the navigation; "Leave" replays the click and lands on the target page
- edited → a full page navigation is blocked by the browser's own "Leave site?" prompt

Not exercised end-to-end: saving and then leaving (needs a write against a live backend), so the `_markDirtyStateClean()` call on the save path is verified only by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)