### PR TITLE
Fix empty data tables after leaving and re-entering the panel

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,10 @@ import { contextMixin } from "@ha/state/context-mixin";
 
 import type { HomeAssistant, Route } from "@ha/types";
 
+import {
+  dropDeadConnectionCollections,
+  releaseConnectionCollectionsOnUnload,
+} from "./utils/connection-collections";
 import { KnxElement } from "./knx";
 import "./knx-router";
 import { showKnxSendDialog } from "./dialogs/show-knx-send-dialog";
@@ -45,6 +49,12 @@ class KnxFrontend extends contextMixin(KnxElement) {
     if (!this.hass) {
       return;
     }
+    // The panel is embedded in an iframe, so websocket collections cached on the
+    // shared connection may belong to the realm of a previous panel instance.
+    // Clean those up before anything subscribes - and don't leave ours behind.
+    dropDeadConnectionCollections(this.hass.connection);
+    releaseConnectionCollectionsOnUnload(this.hass.connection);
+
     // connect contexts by contextMixin
     this.hassConnected();
 

--- a/src/utils/connection-collections.test.ts
+++ b/src/utils/connection-collections.test.ts
@@ -1,0 +1,77 @@
+import type { Connection } from "home-assistant-js-websocket";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  dropDeadConnectionCollections,
+  releaseConnectionCollectionsOnUnload,
+} from "./connection-collections";
+
+/** Minimal stand-in for a `getCollection()` result, built in the given realm. */
+const createCollection = (realm: Window & typeof globalThis) => {
+  const collection = new realm.Object() as Record<string, unknown>;
+  collection.subscribe = new realm.Function("return () => {}")();
+  collection.refresh = new realm.Function("return () => Promise.resolve()")();
+  return collection;
+};
+
+const foreignRealms: HTMLIFrameElement[] = [];
+
+/** An iframe realm that is not an ancestor of the test window. */
+const createForeignRealm = (): Window & typeof globalThis => {
+  const frame = document.createElement("iframe");
+  document.body.appendChild(frame);
+  foreignRealms.push(frame);
+  return frame.contentWindow as Window & typeof globalThis;
+};
+
+const createConnection = (entries: Record<string, unknown>) => entries as unknown as Connection;
+
+afterEach(() => {
+  foreignRealms.splice(0).forEach((frame) => frame.remove());
+});
+
+describe("dropDeadConnectionCollections", () => {
+  it("keeps collections created by this realm", () => {
+    const connection = createConnection({ _entityRegistry: createCollection(window) });
+
+    dropDeadConnectionCollections(connection);
+
+    expect("_entityRegistry" in connection).toBe(true);
+  });
+
+  it("drops collections created by another realm", () => {
+    const connection = createConnection({
+      _entityRegistry: createCollection(createForeignRealm()),
+      _labelRegistry: createCollection(window),
+    });
+
+    dropDeadConnectionCollections(connection);
+
+    expect("_entityRegistry" in connection).toBe(false);
+    expect("_labelRegistry" in connection).toBe(true);
+  });
+
+  it("ignores connection properties that are not collections", () => {
+    const connection = createConnection({
+      socket: {},
+      options: { auth: "token" },
+      _handleMessage: () => undefined,
+    });
+
+    dropDeadConnectionCollections(connection);
+
+    expect(Object.keys(connection)).toEqual(["socket", "options", "_handleMessage"]);
+  });
+});
+
+describe("releaseConnectionCollectionsOnUnload", () => {
+  it("does not register a listener when not embedded in an iframe", () => {
+    // `window.parent === window` in the test environment
+    const connection = createConnection({ _entityRegistry: createCollection(window) });
+
+    releaseConnectionCollectionsOnUnload(connection);
+    window.dispatchEvent(new Event("pagehide"));
+
+    expect("_entityRegistry" in connection).toBe(true);
+  });
+});

--- a/src/utils/connection-collections.ts
+++ b/src/utils/connection-collections.ts
@@ -1,0 +1,92 @@
+import type { Connection } from "home-assistant-js-websocket";
+
+import { KNXLogger } from "../tools/knx-logger";
+
+const logger = new KNXLogger("connection-collections");
+
+/**
+ * Duck-typed shape of a `getCollection()` result (home-assistant-js-websocket).
+ * Those objects are cached on the `Connection` under a private key, e.g.
+ * `_entityRegistry` or `_labelRegistry`.
+ */
+interface CachedCollection {
+  refresh: () => Promise<unknown>;
+  subscribe: (subscriber: (state: any) => void) => () => void;
+}
+
+const isCachedCollection = (value: unknown): value is CachedCollection =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as CachedCollection).subscribe === "function" &&
+  typeof (value as CachedCollection).refresh === "function";
+
+/** Whether the function was created by this window or a same-origin ancestor. */
+const belongsToLivingRealm = (fn: CachedCollection["subscribe"]): boolean => {
+  let win: Window = window;
+  for (;;) {
+    try {
+      if (fn instanceof (win as Window & typeof globalThis).Function) {
+        return true;
+      }
+    } catch (_err) {
+      // cross-origin ancestor - not inspectable, so it isn't one of ours either
+      return false;
+    }
+    if (win.parent === win) {
+      return false;
+    }
+    win = win.parent;
+  }
+};
+
+const ownCollectionKeys = (connection: Connection, ownRealmOnly: boolean): string[] =>
+  Object.entries(connection)
+    .filter(
+      ([, value]) =>
+        isCachedCollection(value) &&
+        (ownRealmOnly
+          ? value.subscribe instanceof Function
+          : !belongsToLivingRealm(value.subscribe)),
+    )
+    .map(([key]) => key);
+
+/**
+ * Home Assistant caches websocket collections (entity registry, label registry, ...)
+ * on the shared `Connection` object. The KNX panel is registered with `embed_iframe`,
+ * so a collection that our bundle is the first to request is created in the iframe
+ * realm while the `Connection` itself lives in the main window.
+ *
+ * When the user navigates to another panel, `ha-panel-custom` removes the iframe and
+ * our realm is destroyed - but the collection object stays cached on the connection.
+ * Its store and the `setTimeout` that hands the cached state to new subscribers are
+ * dead, so the next subscriber (a new KNX iframe, or the main frontend itself) never
+ * receives a value and waits forever. That is what left the entities data table empty
+ * after leaving and re-entering the panel.
+ *
+ * Dropping the orphans makes the next `getCollection()` recreate them in a live realm.
+ */
+export const dropDeadConnectionCollections = (connection: Connection): void => {
+  for (const key of ownCollectionKeys(connection, false)) {
+    logger.debug(`Dropping collection "${key}" cached by a destroyed realm.`);
+    delete (connection as unknown as Record<string, unknown>)[key];
+  }
+};
+
+/**
+ * Counterpart of `dropDeadConnectionCollections`: remove the collections this realm
+ * created from the shared connection before the iframe goes away, so neither the main
+ * frontend nor the next KNX iframe inherits a dead cache.
+ *
+ * `pagehide` fires on the iframe window when `ha-panel-custom` removes the iframe.
+ */
+export const releaseConnectionCollectionsOnUnload = (connection: Connection): void => {
+  if (window.parent === window) {
+    // not embedded - the connection is torn down together with this window
+    return;
+  }
+  window.addEventListener("pagehide", () => {
+    for (const key of ownCollectionKeys(connection, true)) {
+      delete (connection as unknown as Record<string, unknown>)[key];
+    }
+  });
+};


### PR DESCRIPTION
## Problem

Starting from `/knx/entities/view`, clicking **History** in the HA sidebar and then navigating back via *Settings → KNX → Entities* leaves the entities data table completely empty. Same for the other views that depend on the entity registry.

## Cause

The panel is registered with `embed_iframe`, so `knx-frontend` runs in an iframe while `hass.connection` belongs to the main window. `getCollection()` (home-assistant-js-websocket) caches collections **on the connection object** (`_entityRegistry`, `_labelRegistry`) — including their store and the `setTimeout` that hands the cached state to later subscribers.

Since HA now serves `fullEntitiesContext` and `labelsContext` through `LazyContextProvider`, they are only subscribed on demand. On a fresh load of `/knx/entities/view` our iframe is the first to ask, so both collections are created **in the iframe realm**. Navigating away makes `ha-panel-custom` drop the iframe and destroy that realm, but the stale collection object stays cached on the connection. On return, `getCollection()` hands it back and its `setTimeout` never fires — the contexts never deliver a value.

Observed in a running instance after the round trip:

```
_entityRegistry realm = dead, _labelRegistry realm = dead
_knx_entities = 0, _labels = 0, __original__knx_entities = 0
LazyContextProvider: { _loaded: false, _subscribing: true, _pendingCallbacks: 1 }
```

`entitiesByGroupContext` still loads (plain WS call, 25 groups), but every group ends up as `{ui: [], yaml: []}` because `KnxEntitiesByGroupContextProvider` subscribes to the entity registry too — so the `@transform` filter on `_knx_entities` matches nothing.

## Change

New `src/utils/connection-collections.ts`, called from `main.ts` before `hassConnected()`:

- `dropDeadConnectionCollections()` — on startup, delete every cached collection whose `subscribe` was created by a realm that is neither this window nor a same-origin ancestor, so the next `getCollection()` recreates it in a live realm.
- `releaseConnectionCollectionsOnUnload()` — on `pagehide` (which does fire when `ha-panel-custom` removes the iframe), delete the collections *this* realm created, so neither the main frontend nor the next iframe inherits a dead cache.

Both are no-ops when not embedded (`window.parent === window`).

## Verification

Manually reproduced and verified against a running HA instance with a dev build:

```
initial:      knx=16 rows=16 labels=2   _entityRegistry realm = currentIframe
after leave:  _entityRegistry deleted   (pagehide cleanup)
after return: knx=16 rows=16 labels=2   _entityRegistry realm = currentIframe
```

Plus three more round trips through History and HA's own `/config/entities`: still 16 rows, and both registries end up owned by the main-window realm once it asks first. Rendered rows confirmed in the DOM.

`yarn test` passes (272, 4 new), eslint/prettier clean, `lint:types` unchanged.

## Note for reviewers

The second half (`pagehide` cleanup) also protects the rest of the frontend: without it, HA's own entity-registry-backed pages can pick up the dead collection after a visit to the KNX panel. This is arguably an upstream-shaped issue — any `embed_iframe` custom panel that wins the race to create a lazy collection poisons the shared connection — so it may be worth reporting to `home-assistant/frontend` as well. This PR is the defensive fix on our side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
