### PR TITLE
Add select entity UI support

### DIFF
--- a/src/components/knx-form.ts
+++ b/src/components/knx-form.ts
@@ -13,6 +13,7 @@ import type { HomeAssistant, ValueChangedEvent } from "@ha/types";
 import type { ControlSelectOption } from "@ha/components/ha-control-select";
 
 import "./knx-group-address-selector";
+import "./knx-select-options-list";
 import "./knx-payload-selector";
 import "./knx-selector-row";
 import "./knx-sync-state-selector-row";
@@ -205,6 +206,22 @@ export class KnxForm extends LitElement {
             .localizeFunction=${this.backendLocalize}
             @value-changed=${this._updateConfig}
           ></knx-payload-selector>
+        `;
+      }
+      case "knx_select_options": {
+        const optionsGaPath = pathAdd(path, selector.ga_path);
+        return html`
+          <knx-select-options-list
+            .hass=${this.hass}
+            .knx=${this.knx}
+            .key=${selectorPath}
+            .gaKey=${optionsGaPath}
+            .dpt=${getNestedValue(this.config!, optionsGaPath)?.dpt}
+            .value=${getNestedValue(this.config!, selectorPath)}
+            .validationErrors=${selectorErrors}
+            .localizeFunction=${this.backendLocalize}
+            @value-changed=${this._updateConfig}
+          ></knx-select-options-list>
         `;
       }
       case "knx_sync_state":

--- a/src/components/knx-form.ts
+++ b/src/components/knx-form.ts
@@ -216,6 +216,7 @@ export class KnxForm extends LitElement {
             .knx=${this.knx}
             .key=${selectorPath}
             .gaKey=${optionsGaPath}
+            .required=${selector.required}
             .dpt=${getNestedValue(this.config!, optionsGaPath)?.dpt}
             .value=${getNestedValue(this.config!, selectorPath)}
             .validationErrors=${selectorErrors}

--- a/src/components/knx-payload-selector.ts
+++ b/src/components/knx-payload-selector.ts
@@ -145,8 +145,12 @@ export class KnxPayloadSelector extends LitElement {
     this._emitValue();
   }
 
-  /** Typed value to use for a DPT - keeps the current value if it still fits and
-   * falls back to a default so required fields validate without user input. */
+  /** Typed value to use for a DPT.
+   *
+   * Numeric, enum and string values are kept when they still fit the DPT, while
+   * complex values are reset - their fields are specific to the previous DPT.
+   * Otherwise a default is used, so required fields validate without user input.
+   */
   private _typedValueForDpt(dptMeta?: DPTMetadata): PayloadConfigValue["value"] {
     if (!dptMeta) {
       return undefined;

--- a/src/components/knx-payload-selector.ts
+++ b/src/components/knx-payload-selector.ts
@@ -8,6 +8,7 @@ import "@ha/components/ha-selector/ha-selector";
 import "@ha/components/input/ha-input";
 
 import { fireEvent } from "@ha/common/dom/fire_event";
+import { conditionalClamp } from "@ha/common/number/clamp";
 import type { HaInput } from "@ha/components/input/ha-input";
 import type { NumberSelector, SelectSelector, StringSelector } from "@ha/data/selector";
 import type { HomeAssistant } from "@ha/types";
@@ -105,44 +106,111 @@ export class KnxPayloadSelector extends LitElement {
   }
 
   protected willUpdate(changedProperties: PropertyValues): void {
-    if (!this._initialized && changedProperties.has("value")) {
+    const firstInit = !this._initialized && changedProperties.has("value");
+    if (firstInit) {
       this._mode = this._inferMode();
       this._typedValue = this.value?.value;
       this._rawPayload = this.value?.payload;
       const rawLength = this.value?.payload_length ?? 1;
       this._rawLength = this._clampRawLength(rawLength);
       this._initialized = true;
-    } else if (changedProperties.has("dpt") || changedProperties.has("_linkedDpt")) {
-      this._mode = this._inferMode();
-      const dpt = this._effectiveDpt();
-      const dptMeta = dpt ? this.knx.dptMetadata[dpt] : undefined;
-      if (dptMeta?.dpt_class === "numeric" && typeof this._typedValue === "number") {
-        this._typedValue = Math.min(
-          dptMeta.max ?? this._typedValue,
-          Math.max(dptMeta.min ?? this._typedValue, this._typedValue),
-        );
-      } else if (
-        dptMeta?.dpt_class === "enum" &&
-        dptMeta.options &&
-        !dptMeta.options.includes(this._typedValue as string)
-      ) {
-        // set initial value for enum selector
-        this._typedValue = dptMeta.options[0];
-      } else if (dptMeta?.dpt_class === "complex" && dptMeta.schema) {
-        this._typedValue = {};
-        // set initial values for enum fields in complex DPTs
-        for (const field of dptMeta.schema) {
-          if (field.type === "enum" && field.required && field.options) {
-            this._typedValue[field.name] = field.options[0];
-          }
+    }
+    const dptChanged = changedProperties.has("dpt") || changedProperties.has("_linkedDpt");
+    // Apply defaults when the DPT changes, or on first init when a DPT is already
+    // selected but no typed value exists yet (e.g. a freshly added select option) -
+    // otherwise required fields would stay unset.
+    if (dptChanged || (firstInit && this._typedValue === undefined)) {
+      this._applyDptTypedDefaults();
+    }
+  }
+
+  private _applyDptTypedDefaults(): void {
+    this._mode = this._inferMode();
+    const dpt = this._effectiveDpt();
+    const dptMeta = dpt ? this.knx.dptMetadata[dpt] : undefined;
+    const typedValue = this._typedValueForDpt(dptMeta);
+    const rawLength = dptMeta?.payload_length ?? this._clampRawLength(this._rawLength);
+    const rawPayload = this._clampRawPayload(this._rawPayload);
+
+    if (
+      typedValue === this._typedValue &&
+      rawLength === this._rawLength &&
+      rawPayload === this._rawPayload
+    ) {
+      return; // nothing to apply - don't emit a redundant update
+    }
+    this._typedValue = typedValue;
+    this._rawLength = rawLength;
+    this._rawPayload = rawPayload;
+    this._emitValue();
+  }
+
+  /** Typed value to use for a DPT - keeps the current value if it still fits and
+   * falls back to a default so required fields validate without user input. */
+  private _typedValueForDpt(dptMeta?: DPTMetadata): PayloadConfigValue["value"] {
+    if (!dptMeta) {
+      return undefined;
+    }
+    switch (dptMeta.dpt_class) {
+      case "numeric":
+        if (typeof this._typedValue === "number") {
+          return conditionalClamp(this._typedValue, dptMeta.min, dptMeta.max);
         }
-      } else {
-        this._typedValue = undefined;
+        // default to 0, clamped into range; defaulting to the min would be
+        // awkward for signed int / float DPTs
+        return this.required ? conditionalClamp(0, dptMeta.min, dptMeta.max) : undefined;
+      case "enum":
+        return dptMeta.options?.includes(this._typedValue as string)
+          ? this._typedValue
+          : dptMeta.options?.[0];
+      case "complex":
+        return dptMeta.schema ? this._complexDefaults(dptMeta.schema) : undefined;
+      case "string":
+        if (typeof this._typedValue === "string") {
+          return this._typedValue;
+        }
+        // an empty string is a valid payload, so it can serve as default
+        return this.required ? "" : undefined;
+      default:
+        return undefined;
+    }
+  }
+
+  // Default values for the required fields of a complex DPT, matching what the
+  // field selectors display, so the emitted value validates without user input.
+  private _complexDefaults(schema: DPTComplexFieldSchema[]): Record<string, unknown> {
+    const value: Record<string, unknown> = {};
+    for (const field of schema) {
+      if (!field.required) {
+        continue;
       }
-      const dptPayloadLength = dptMeta ? dptMeta.payload_length : undefined;
-      this._rawLength = dptPayloadLength ?? this._clampRawLength(this._rawLength);
-      this._rawPayload = this._clampRawPayload(this._rawPayload);
-      this._emitValue();
+      const fieldDefault = this._complexFieldDefault(field);
+      if (fieldDefault !== undefined) {
+        value[field.name] = fieldDefault;
+      }
+    }
+    return value;
+  }
+
+  private _complexFieldDefault(
+    field: DPTComplexFieldSchema,
+  ): number | boolean | string | undefined {
+    if (field.default !== undefined) {
+      return field.default;
+    }
+    switch (field.type) {
+      case "boolean":
+        return false;
+      case "enum":
+        return field.options?.[0];
+      case "integer":
+      case "float":
+        // default to 0, clamped into range (min would be awkward for signed types)
+        return conditionalClamp(0, field.value_min, field.value_max);
+      case "string":
+        return "";
+      default:
+        return undefined;
     }
   }
 
@@ -587,10 +655,10 @@ export class KnxPayloadSelector extends LitElement {
           ? { payload: this._rawPayload, payload_length: this._effectiveRawLength }
           : undefined;
     } else {
-      value =
-        this._typedValue !== undefined && this._typedValue !== ""
-          ? { value: this._typedValue }
-          : undefined;
+      // an empty string is a valid value for required fields - so it can be set
+      // deliberately; for optional ones clearing the input means "no value"
+      const isSet = this._typedValue !== undefined && (this.required || this._typedValue !== "");
+      value = isSet ? { value: this._typedValue } : undefined;
     }
     fireEvent(this, "value-changed", { value });
   }

--- a/src/components/knx-payload-selector.ts
+++ b/src/components/knx-payload-selector.ts
@@ -48,6 +48,10 @@ export class KnxPayloadSelector extends LitElement {
 
   @property({ type: Boolean, attribute: "disable-raw" }) public disableRaw?: boolean;
 
+  // When set, the raw payload length is controlled externally (e.g. one shared
+  // length for a whole options list) - the internal length selector is hidden.
+  @property({ attribute: false }) public rawLength?: number;
+
   @property({ attribute: false }) public value?: PayloadConfigValue;
 
   @property({ attribute: false }) public validationErrors?: ErrorDescription[];
@@ -375,7 +379,33 @@ export class KnxPayloadSelector extends LitElement {
     const rawLengthSelector: NumberSelector = {
       number: { mode: "box", min: 0, max: maxLength, step: 1 },
     };
-    const disableLength = this._effectiveDpt() !== undefined;
+    // hide the length selector when the length is fixed - either controlled
+    // externally (`rawLength`) or derived from a selected DPT.
+    const showLength = this.rawLength === undefined && this._effectiveDpt() === undefined;
+
+    const payload = html`
+      <div class="raw-payload">
+        <ha-control-select
+          .label=${this._localizeSelector("raw_payload_base_label")}
+          .options=${[
+            { value: "dec", label: "Dec" },
+            { value: "hex", label: "Hex" },
+          ]}
+          .value=${this._rawPayloadBase}
+          @value-changed=${this._rawPayloadBaseChanged}
+          vertical
+        ></ha-control-select>
+        ${
+          this._rawPayloadBase === "hex"
+            ? this._renderRawPayloadValueHex()
+            : this._renderRawPayloadValueDec()
+        }
+      </div>
+    `;
+
+    if (!showLength) {
+      return payload;
+    }
 
     return html`
       <div class="raw-grid">
@@ -383,28 +413,11 @@ export class KnxPayloadSelector extends LitElement {
           .hass=${this.hass}
           .selector=${rawLengthSelector}
           .label=${this._localizeSelector("raw_length")}
-          .helper=${`${disableLength ? "" : numberRangeHelper(0, maxLength) + " "}${this._localizeSelector("raw_length_description")}`}
+          .helper=${`${numberRangeHelper(0, maxLength)} ${this._localizeSelector("raw_length_description")}`}
           .value=${this._rawLength}
           @value-changed=${this._rawLengthChanged}
-          .disabled=${disableLength}
         ></ha-selector>
-        <div class="raw-payload">
-          <ha-control-select
-            .label=${this._localizeSelector("raw_payload_base_label")}
-            .options=${[
-              { value: "dec", label: "Dec" },
-              { value: "hex", label: "Hex" },
-            ]}
-            .value=${this._rawPayloadBase}
-            @value-changed=${this._rawPayloadBaseChanged}
-            vertical
-          ></ha-control-select>
-          ${
-            this._rawPayloadBase === "hex"
-              ? this._renderRawPayloadValueHex()
-              : this._renderRawPayloadValueDec()
-          }
-        </div>
+        ${payload}
       </div>
     `;
   }
@@ -432,7 +445,7 @@ export class KnxPayloadSelector extends LitElement {
       @change=${this._rawPayloadChanged}
       .label=${this._localizeSelector("raw_payload")}
       .required=${true}
-      .maxlength=${(this._rawLength || 1) * 2}
+      .maxlength=${(this._effectiveRawLength || 1) * 2}
       .invalid=${!!rawInvalidMessage}
       .validationMessage=${rawInvalidMessage}
     >
@@ -544,7 +557,7 @@ export class KnxPayloadSelector extends LitElement {
         return 63n;
       }
     }
-    return this._rawLength === 0 ? 63n : 2n ** BigInt(this._rawLength * 8) - 1n;
+    return this._effectiveRawLength === 0 ? 63n : 2n ** BigInt(this._effectiveRawLength * 8) - 1n;
   }
 
   private _clampRawPayload(payload: string | undefined): string | undefined {
@@ -571,7 +584,7 @@ export class KnxPayloadSelector extends LitElement {
     if (this._mode === "raw") {
       value =
         this._rawPayload !== undefined
-          ? { payload: this._rawPayload, payload_length: this._rawLength }
+          ? { payload: this._rawPayload, payload_length: this._effectiveRawLength }
           : undefined;
     } else {
       value =
@@ -596,6 +609,10 @@ export class KnxPayloadSelector extends LitElement {
 
   private _effectiveDpt(): string | undefined {
     return this.dpt ?? this._linkedDpt;
+  }
+
+  private get _effectiveRawLength(): number {
+    return this.rawLength ?? this._rawLength;
   }
 
   private _handleGroupAddressChanged = (ev: CustomEvent<{ key: string; dpt?: string }>) => {

--- a/src/components/knx-select-options-list.ts
+++ b/src/components/knx-select-options-list.ts
@@ -11,6 +11,7 @@ import "@ha/components/ha-svg-icon";
 import "@ha/components/input/ha-input";
 
 import { fireEvent } from "@ha/common/dom/fire_event";
+import { clamp } from "@ha/common/number/clamp";
 import type { HaInput } from "@ha/components/input/ha-input";
 import type { NumberSelector } from "@ha/data/selector";
 import type { HomeAssistant } from "@ha/types";
@@ -24,6 +25,9 @@ import type { KNX } from "../types/knx";
 export interface SelectOption extends PayloadConfigValue {
   option: string;
 }
+
+// maximum KNX payload length in bytes
+const MAX_PAYLOAD_LENGTH = 14;
 
 @customElement("knx-select-options-list")
 export class KnxSelectOptionsList extends LitElement {
@@ -114,7 +118,11 @@ export class KnxSelectOptionsList extends LitElement {
           : html`<ha-selector
               class="payload-length"
               .hass=${this.hass}
-              .selector=${{ number: { mode: "box", min: 0, max: 14, step: 1 } } as NumberSelector}
+              .selector=${
+                {
+                  number: { mode: "box", min: 0, max: MAX_PAYLOAD_LENGTH, step: 1 },
+                } as NumberSelector
+              }
               .label=${this._localizePayload("raw_length")}
               .helper=${this._localizePayload("raw_length_description")}
               .value=${this._payloadLength}
@@ -162,6 +170,7 @@ export class KnxSelectOptionsList extends LitElement {
         .gaKey=${this.gaKey}
         .dpt=${this._effectiveDpt}
         .rawLength=${this._effectiveDpt ? undefined : this._payloadLength}
+        .required=${true}
         .value=${payload as PayloadConfigValue}
         .localizeFunction=${this._emptyLocalize}
         data-index=${index}
@@ -178,7 +187,7 @@ export class KnxSelectOptionsList extends LitElement {
   private _payloadLengthChanged(ev: CustomEvent<{ value: number }>): void {
     ev.stopPropagation();
     const length = Math.floor(Number(ev.detail.value));
-    this._payloadLength = Number.isFinite(length) ? Math.min(14, Math.max(0, length)) : 1;
+    this._payloadLength = Number.isFinite(length) ? clamp(length, 0, MAX_PAYLOAD_LENGTH) : 1;
     // apply the shared length to every raw option
     const options = (this.value ?? []).map((o) =>
       o.payload !== undefined ? { ...o, payload_length: this._payloadLength } : o,

--- a/src/components/knx-select-options-list.ts
+++ b/src/components/knx-select-options-list.ts
@@ -42,6 +42,8 @@ export class KnxSelectOptionsList extends LitElement {
 
   @property({ attribute: false }) public dpt?: string;
 
+  @property({ type: Boolean }) public required?: boolean;
+
   @property({ attribute: false }) public value?: SelectOption[];
 
   @property({ attribute: false }) public validationErrors?: ErrorDescription[];
@@ -101,6 +103,12 @@ export class KnxSelectOptionsList extends LitElement {
     return this.value?.length ? this.value : [{ option: "" }];
   }
 
+  // A required list keeps its last option; an optional one can be cleared
+  // completely. The placeholder row shown for an empty list has nothing to delete.
+  private get _canDeleteOption(): boolean {
+    return this._displayOptions.length > 1 || (!this.required && !!this.value?.length);
+  }
+
   protected render(): TemplateResult {
     const invalid = getValidationError(this.validationErrors);
     const options = this._displayOptions;
@@ -130,7 +138,7 @@ export class KnxSelectOptionsList extends LitElement {
             ></ha-selector>`
       }
       <div class="options">
-        ${options.map((option, index) => this._renderOption(option, index, options.length > 1))}
+        ${options.map((option, index) => this._renderOption(option, index, this._canDeleteOption))}
       </div>
       <ha-button appearance="filled" size="small" @click=${this._addOption}>
         <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
@@ -140,6 +148,8 @@ export class KnxSelectOptionsList extends LitElement {
     `;
   }
 
+  // Name and payload are always required - an option row that exists has to be
+  // complete, no matter whether the list itself is required.
   private _renderOption(option: SelectOption, index: number, canDelete: boolean): TemplateResult {
     const { option: name, ...payload } = option;
     return html`<div class="option">

--- a/src/components/knx-select-options-list.ts
+++ b/src/components/knx-select-options-list.ts
@@ -1,0 +1,308 @@
+import { mdiDelete, mdiPlus } from "@mdi/js";
+import { LitElement, css, html, nothing } from "lit";
+import type { PropertyValues, TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators";
+import { classMap } from "lit/directives/class-map";
+
+import "@ha/components/ha-button";
+import "@ha/components/ha-icon-button";
+import "@ha/components/ha-selector/ha-selector";
+import "@ha/components/ha-svg-icon";
+import "@ha/components/input/ha-input";
+
+import { fireEvent } from "@ha/common/dom/fire_event";
+import type { HaInput } from "@ha/components/input/ha-input";
+import type { NumberSelector } from "@ha/data/selector";
+import type { HomeAssistant } from "@ha/types";
+
+import "./knx-payload-selector";
+import type { PayloadConfigValue } from "./knx-payload-selector";
+import { getValidationError } from "../utils/validation";
+import type { ErrorDescription } from "../types/entity_data";
+import type { KNX } from "../types/knx";
+
+export interface SelectOption extends PayloadConfigValue {
+  option: string;
+}
+
+@customElement("knx-select-options-list")
+export class KnxSelectOptionsList extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ attribute: false }) public knx!: KNX;
+
+  @property() public key!: string;
+
+  // Relative path to the linked group address, used by the payload selectors.
+  @property({ attribute: false }) public gaKey?: string;
+
+  @property({ attribute: false }) public dpt?: string;
+
+  @property({ attribute: false }) public value?: SelectOption[];
+
+  @property({ attribute: false }) public validationErrors?: ErrorDescription[];
+
+  @property({ attribute: false }) public localizeFunction: (key: string) => string = (
+    key: string,
+  ) => key;
+
+  // DPT of the linked group address, tracked live so options added after the DPT
+  // was selected still see it (they miss the initial knx-dpt-selector-changed event).
+  @state() private _linkedDpt?: string;
+
+  // One shared raw payload length for all options (they all target the same address).
+  @state() private _payloadLength = 1;
+
+  private _lengthInitialized = false;
+
+  protected willUpdate(changedProperties: PropertyValues): void {
+    if (!this._lengthInitialized && changedProperties.has("value") && this.value?.length) {
+      const withLength = this.value.find((o) => typeof o.payload_length === "number");
+      if (withLength?.payload_length !== undefined) {
+        this._payloadLength = withLength.payload_length;
+      }
+      this._lengthInitialized = true;
+    }
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    window.addEventListener(
+      "knx-dpt-selector-changed",
+      this._handleGroupAddressChanged as EventListener,
+    );
+  }
+
+  disconnectedCallback(): void {
+    window.removeEventListener(
+      "knx-dpt-selector-changed",
+      this._handleGroupAddressChanged as EventListener,
+    );
+    super.disconnectedCallback();
+  }
+
+  private _handleGroupAddressChanged = (ev: CustomEvent<{ key: string; dpt?: string }>) => {
+    if (!this.gaKey || ev.detail.key !== this.gaKey) {
+      return;
+    }
+    this._linkedDpt = ev.detail.dpt;
+  };
+
+  private get _effectiveDpt(): string | undefined {
+    return this.dpt ?? this._linkedDpt;
+  }
+
+  // Always show at least one (empty) option row, like the expose editor.
+  private get _displayOptions(): SelectOption[] {
+    return this.value?.length ? this.value : [{ option: "" }];
+  }
+
+  protected render(): TemplateResult {
+    const invalid = getValidationError(this.validationErrors);
+    const options = this._displayOptions;
+
+    return html`
+      <div class="text">
+        <p class="heading ${classMap({ invalid: !!invalid })}">
+          ${this.localizeFunction(this.key + ".label")}
+        </p>
+        <p class="description">${this.localizeFunction(this.key + ".description")}</p>
+      </div>
+      ${
+        this._effectiveDpt
+          ? nothing
+          : html`<ha-selector
+              class="payload-length"
+              .hass=${this.hass}
+              .selector=${{ number: { mode: "box", min: 0, max: 14, step: 1 } } as NumberSelector}
+              .label=${this._localizePayload("raw_length")}
+              .helper=${this._localizePayload("raw_length_description")}
+              .value=${this._payloadLength}
+              @value-changed=${this._payloadLengthChanged}
+            ></ha-selector>`
+      }
+      <div class="options">
+        ${options.map((option, index) => this._renderOption(option, index, options.length > 1))}
+      </div>
+      <ha-button appearance="filled" size="small" @click=${this._addOption}>
+        <ha-svg-icon slot="start" .path=${mdiPlus}></ha-svg-icon>
+        ${this._localize("add_option")}
+      </ha-button>
+      ${invalid ? html`<p class="invalid-message">${invalid.message}</p>` : nothing}
+    `;
+  }
+
+  private _renderOption(option: SelectOption, index: number, canDelete: boolean): TemplateResult {
+    const { option: name, ...payload } = option;
+    return html`<div class="option">
+      <div class="option-header">
+        <ha-input
+          class="option-name"
+          .value=${name ?? ""}
+          .label=${this._localize("option")}
+          .type=${"text"}
+          .required=${true}
+          data-index=${index}
+          @input=${this._optionNameChanged}
+          @change=${this._optionNameChanged}
+        ></ha-input>
+        <ha-icon-button
+          class="remove"
+          .path=${mdiDelete}
+          .label=${this.hass.localize("ui.common.remove")}
+          .disabled=${!canDelete}
+          data-index=${index}
+          @click=${this._removeOption}
+        ></ha-icon-button>
+      </div>
+      <knx-payload-selector
+        .hass=${this.hass}
+        .knx=${this.knx}
+        .key=${`${this.key}_${index}`}
+        .gaKey=${this.gaKey}
+        .dpt=${this._effectiveDpt}
+        .rawLength=${this._effectiveDpt ? undefined : this._payloadLength}
+        .value=${payload as PayloadConfigValue}
+        .localizeFunction=${this._emptyLocalize}
+        data-index=${index}
+        @value-changed=${this._payloadChanged}
+      ></knx-payload-selector>
+    </div>`;
+  }
+
+  private _emptyLocalize = (_key: string): string => "";
+
+  private _localizePayload = (key: string): string =>
+    this.hass.localize(`component.knx.config_panel.selectors.knx-payload-selector.${key}`);
+
+  private _payloadLengthChanged(ev: CustomEvent<{ value: number }>): void {
+    ev.stopPropagation();
+    const length = Math.floor(Number(ev.detail.value));
+    this._payloadLength = Number.isFinite(length) ? Math.min(14, Math.max(0, length)) : 1;
+    // apply the shared length to every raw option
+    const options = (this.value ?? []).map((o) =>
+      o.payload !== undefined ? { ...o, payload_length: this._payloadLength } : o,
+    );
+    if (options.length) {
+      this._emit(options);
+    }
+  }
+
+  private _optionNameChanged(ev: Event): void {
+    const index = this._indexOf(ev);
+    this._updateOption(index, { option: (ev.target as HaInput).value ?? "" });
+  }
+
+  private _payloadChanged(ev: CustomEvent<{ value: PayloadConfigValue | undefined }>): void {
+    ev.stopPropagation();
+    const index = this._indexOf(ev);
+    const options = [...this._displayOptions];
+    const current = options[index];
+    if (!current) return;
+    options[index] = { option: current.option, ...(ev.detail.value ?? {}) };
+    this._emit(options);
+  }
+
+  private _addOption(): void {
+    this._emit([...this._displayOptions, { option: "" }]);
+  }
+
+  private _removeOption(ev: Event): void {
+    const index = this._indexOf(ev);
+    const options = [...this._displayOptions];
+    options.splice(index, 1);
+    this._emit(options);
+  }
+
+  private _updateOption(index: number, patch: Partial<SelectOption>): void {
+    const options = [...this._displayOptions];
+    if (!options[index]) return;
+    options[index] = { ...options[index], ...patch };
+    this._emit(options);
+  }
+
+  private _emit(options: SelectOption[]): void {
+    fireEvent(this, "value-changed", { value: options.length ? options : undefined });
+  }
+
+  private _indexOf(ev: Event): number {
+    return Number((ev.currentTarget as HTMLElement).dataset.index);
+  }
+
+  private _localize = (key: string): string =>
+    this.hass.localize(`component.knx.config_panel.selectors.knx-select-options-selector.${key}`);
+
+  static styles = css`
+    :host {
+      display: block;
+      padding: 8px 16px 8px 0;
+      border-top: 1px solid var(--divider-color);
+    }
+
+    .text {
+      margin-bottom: 8px;
+    }
+
+    .heading {
+      margin: 0;
+    }
+
+    .description {
+      margin: 0;
+      padding-top: 4px;
+      color: var(--secondary-text-color);
+      font-size: var(--ha-font-size-s);
+    }
+
+    .payload-length {
+      display: block;
+      max-width: 220px;
+      margin-bottom: 12px;
+    }
+
+    .options {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+
+    .option {
+      border: 1px solid var(--divider-color);
+      border-radius: 8px;
+      padding: 8px 12px;
+    }
+
+    .option-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .option-name {
+      flex: 1;
+    }
+
+    knx-payload-selector {
+      border-top: 0;
+      padding-bottom: 0;
+    }
+
+    .invalid {
+      color: var(--error-color);
+    }
+
+    .invalid-message {
+      font-size: 0.75rem;
+      color: var(--error-color);
+      padding-left: 16px;
+      margin: 6px 0 0;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "knx-select-options-list": KnxSelectOptionsList;
+  }
+}

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -8,6 +8,7 @@ export type SelectorSchema =
   | GASelector
   | SyncStateSelector
   | PayloadSelector
+  | SelectOptionsSelector
   | KnxHaSelector;
 
 interface BaseSection {
@@ -63,6 +64,14 @@ export interface PayloadSelectorWithDpt extends PayloadSelectorBase {
 }
 
 export type PayloadSelector = PayloadSelectorWithGaPath | PayloadSelectorWithDpt;
+
+export interface SelectOptionsSelector {
+  type: "knx_select_options";
+  name: string;
+  // Relative path to the linked group address, used to resolve its DPT.
+  ga_path: string;
+  required?: boolean;
+}
 
 export interface KnxHaSelector {
   type: "ha_selector";


### PR DESCRIPTION
Adds UI support for the KNX `select` entity platform, plus the shared payload-selector improvements it needed.

Requires the corresponding core PR that adds the `select` entity store schema (`knx_select_options` selector type) — the panel renders whatever the backend serializes, so this can be merged independently, but the select platform only appears once core ships the schema.

## New: `<knx-select-options-list>`

Renders the new `knx_select_options` selector — a list of options, each mapping a name to a payload:

- one option row per entry, each embedding `<knx-payload-selector>` so options get the full **Typed value / Raw payload** experience (DPT-derived inputs for enum/numeric/string/complex)
- always shows at least one (empty) option row, like the expose editor; the last remaining option can't be deleted
- a single shared **payload length** for all options (they target the same group address), shown only when no DPT is selected — the per-option selectors then hide their own length field
- prominent "+ Add option" button, trashcan icon to remove an option
- tracks the linked group address's DPT live via `knx-dpt-selector-changed`, so options added *after* a DPT was picked still get typed mode

## Changes to `<knx-payload-selector>`

These are shared with the button/notify `data` fields:

- new `rawLength` property — when the length is controlled externally, the internal length selector is hidden
- the length selector is now **hidden** rather than disabled when the length is fixed by a DPT (it was previously rendered greyed-out with no purpose)
- typed defaults are applied on first init too, not only on DPT change — previously a freshly added option with a DPT already selected had "Typed value" disabled and required fields (e.g. `control` of DPT 2.x) stayed unset, so the config didn't validate until the user toggled a field
- default computation extracted into a pure `_typedValueForDpt()`; `_applyDptTypedDefaults()` now only emits when something actually changed, so mounting a selector no longer fires a spurious `value-changed`
- required fields fall back to a value matching what the control displays: `enum` → first option, `boolean` → `false`, numeric → `0` clamped into range (min would be awkward for signed/float), `string` → `""`, complex → all required sub-fields
- an empty string now counts as a value for required fields, so it can be set deliberately / cleared; for optional fields clearing still means "no value"

## Testing

- `yarn test` — 268 passed
- `yarn lint` — eslint and prettier clean; `lint:types` reports only pre-existing errors (`expose_view.ts`, `vitest.config.ts`, and the `ev.target.key` pattern in `knx-form.ts` that is unchanged from `main`)
- manually verified in a running Home Assistant instance against the core branch
