### PR TITLE
Stop shipping source code inside production source maps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,6 @@ jobs:
 
       - name: Build
         run: yarn build
+
+      - name: Report output size
+        run: yarn run build:size

--- a/build-scripts/README.md
+++ b/build-scripts/README.md
@@ -37,3 +37,42 @@ In production, the following responsibilities are added:
 - Generate a second version that is ES5 compatible
 
 Configuration for all these steps are specified in [bundle.js](bundle.js).
+
+## Output size
+
+The published wheel is `knx_frontend/` zipped up, so build output size is what every Home
+Assistant install pays for. `yarn run build:size` prints a per-build, per-file-type breakdown
+(also run in CI after every build). Two settings dominate it:
+
+### Source maps
+
+`devtool` in [rspack.cjs](rspack.cjs) must stay on a `nosources-*` variant for production.
+Anything else embeds `sourcesContent` — the complete pre-minification source of every module,
+homeassistant-frontend and `node_modules` alike — inside every `.js.map`. That was the case
+until 2026-08 and accounted for 48% of the wheel and 67% of the installed size.
+
+Because the maps carry no sources, `output.devtoolModuleFilenameTemplate` rewrites paths to
+GitHub instead, across two source roots:
+
+- `src/` → `XKNX/knx-frontend` at the version in `VERSION`
+- `homeassistant-frontend/src/` → `home-assistant/frontend` at the **pinned submodule commit**.
+  It must point at the upstream repo: raw.githubusercontent.com does not serve submodule
+  contents, so `XKNX/knx-frontend/<tag>/homeassistant-frontend/…` would 404 on every HA frame.
+- everything else → `/unknown/…`, which dev tools request and cheerfully 404 on.
+
+### Camera stubs
+
+`emptyPackages()` in [bundle.cjs](bundle.cjs) replaces hls.js and qr-scanner with an empty
+module. The KNX panel renders no cameras, but it reaches HA components that do, and hls.js alone
+was 1.3 MB of the wheel.
+
+Only packages behind a **dynamic** import can be stubbed. A static `import X from "pkg"` fails
+the build with `export 'default' was not found`, which is why cropperjs is not on the list — do
+not "fix" that by giving [../src/util/empty.js](../src/util/empty.js) a default export, as that
+trades a build error for a silent runtime one. Also check the package is not used at module top
+level (`barcode-detector` is excluded for that reason: an empty module would throw when
+ha-qr-scanner is evaluated rather than when it is used).
+
+Point `require.resolve` at the entry file rspack actually picks: `main` is often the CommonJS
+build while the bundle gets `browser` or `module`, and a stub aimed at the wrong file silently
+matches nothing.

--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -1,3 +1,4 @@
+const { execFileSync } = require("child_process");
 const path = require("path");
 const env = require("./env.cjs");
 const paths = require("./paths.cjs");
@@ -8,12 +9,63 @@ const BABEL_PLUGINS = path.join(
   "homeassistant-frontend/build-scripts/babel-plugins",
 );
 
+// GitHub base URL for production source maps of this repo's own `src/`.
+// Release builds write the tag into VERSION (see .github/workflows/ReleaseActions.yml),
+// so the ref resolves to a real tag; dev builds fall back to the commit SHA.
+module.exports.sourceMapURL = () => {
+  const ref = env.version().endsWith("dev") ? process.env.GITHUB_SHA || "dev" : env.version();
+  return `https://raw.githubusercontent.com/XKNX/knx-frontend/${ref}/`;
+};
+
+// GitHub base URL for production source maps of the homeassistant-frontend submodule.
+// Its sources are NOT reachable under this repo on raw.githubusercontent.com — GitHub raw
+// does not serve submodule contents — so they must point at the upstream repo at the pinned
+// commit. The pin is read from the superproject tree rather than the submodule itself: CI
+// checks out with `submodules: recursive` and no fetch-depth, so the submodule is shallow and
+// its tags are absent (`git describe` would fail there). raw serves a SHA just as well as a tag.
+// Returns undefined if the pin can't be read, in which case callers fall back to /unknown/.
+let haRef;
+module.exports.haSourceMapURL = () => {
+  if (haRef === undefined) {
+    try {
+      const line = execFileSync("git", ["ls-tree", "HEAD", "homeassistant-frontend"], {
+        cwd: paths.root_dir,
+        encoding: "utf-8",
+      });
+      haRef = /^\d+ commit ([0-9a-f]{40})\s/.exec(line)?.[1] ?? null;
+    } catch {
+      haRef = null;
+    }
+  }
+  return haRef ? `https://raw.githubusercontent.com/home-assistant/frontend/${haRef}/` : undefined;
+};
+
 // Files from NPM Packages that should not be imported
 module.exports.ignorePackages = () => [];
 
-// Files from NPM packages that we should replace with empty file
+// Files from NPM packages that we should replace with empty file.
+//
+// The KNX panel renders no cameras, no media browser and no image uploads, so the
+// camera/video/image-processing dependencies HA pulls in are dead weight here — hls.js alone
+// was 1.3 MB of the published wheel.
+//
+// Only packages reached through a *dynamic* import can be stubbed: a static `import X from`
+// fails the build outright with "export 'default' was not found" against the empty module.
+// That rules out "cropperjs" (image-cropper-dialog imports it statically, and it is only
+// ~160 KB). Also excluded: "barcode-detector", which calls prepareZXingModule() at the top
+// level of ha-qr-scanner.ts, so an empty module would throw when that module is evaluated
+// rather than when it is used; and "node-vibrant", at only ~30 KB.
+//
+// See the camera stubs note in build-scripts/README.md before adding to this list.
 module.exports.emptyPackages = () =>
   [
+    // HTTP Live Streaming player, dynamically imported by ha-hls-player for camera streams.
+    require.resolve("hls.js/dist/hls.light.mjs"),
+    // Camera-based QR code scanner, dynamically imported by ha-qr-scanner. Resolve the exact
+    // entry rspack picks (the "module" field), not the bare package — require.resolve() would
+    // give the CommonJS "main" (qr-scanner.umd.min.js), which is never the file in the bundle.
+    require.resolve("qr-scanner/qr-scanner.min.js"),
+
     // Icons in landingpage conflict with icons in HA so we don't load.
     // ... for KNX we seem to need it - probably due to iframe.
     //

--- a/build-scripts/report-output-size.cjs
+++ b/build-scripts/report-output-size.cjs
@@ -1,0 +1,71 @@
+/* global require, process, __dirname */
+// Report the size of the built panel, broken down by file type.
+//
+// The shipped wheel is just `knx_frontend/` zipped up, so this is the number users pay for on
+// every install. It is easy to inflate by accident — a `devtool` setting that embeds
+// `sourcesContent` once made source maps 48% of the wheel and went unnoticed for three years —
+// so print the breakdown on every build and let it show up in CI logs and PR diffs.
+//
+// Usage: node build-scripts/report-output-size.cjs
+
+const fs = require("fs");
+const path = require("path");
+const paths = require("./paths.cjs");
+
+const CATEGORIES = [
+  [".js.map", (f) => f.endsWith(".js.map")],
+  [".js.gz", (f) => f.endsWith(".js.gz")],
+  [".js.br", (f) => f.endsWith(".js.br")],
+  [".js", (f) => f.endsWith(".js")],
+  [".LICENSE.txt", (f) => f.endsWith(".LICENSE.txt")],
+];
+
+const categorize = (file) => CATEGORIES.find(([, test]) => test(file))?.[0] ?? "other";
+
+const walk = function* (dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(full);
+    } else if (entry.isFile()) {
+      yield full;
+    }
+  }
+};
+
+const mb = (bytes) => `${(bytes / 1048576).toFixed(2)} MB`;
+
+const root = paths.knx_output_root;
+if (!fs.existsSync(root)) {
+  console.error(`No build output at ${root}. Run \`yarn build\` first.`);
+  process.exit(1);
+}
+
+const totals = new Map();
+let grandTotal = 0;
+let fileCount = 0;
+for (const file of walk(root)) {
+  const rel = path.relative(root, file);
+  const build = rel.includes(path.sep) ? rel.split(path.sep)[0] : "(root)";
+  const key = `${build}\t${categorize(file)}`;
+  const size = fs.statSync(file).size;
+  const entry = totals.get(key) ?? { count: 0, size: 0 };
+  entry.count += 1;
+  entry.size += size;
+  totals.set(key, entry);
+  grandTotal += size;
+  fileCount += 1;
+}
+
+const rows = [...totals.entries()]
+  .map(([key, v]) => ({ ...v, build: key.split("\t")[0], ext: key.split("\t")[1] }))
+  .sort((a, b) => b.size - a.size);
+
+console.log(`\nBuild output: ${mb(grandTotal)} across ${fileCount} files (${root})\n`);
+console.log(`${"build".padEnd(18)}${"type".padEnd(16)}${"files".padStart(7)}${"size".padStart(12)}`);
+for (const r of rows) {
+  console.log(
+    `${r.build.padEnd(18)}${r.ext.padEnd(16)}${String(r.count).padStart(7)}${mb(r.size).padStart(12)}`,
+  );
+}
+console.log(`${"TOTAL".padEnd(34)}${String(fileCount).padStart(7)}${mb(grandTotal).padStart(12)}\n`);

--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -49,7 +49,12 @@ const createRspackConfig = ({
   return {
     mode: isProdBuild ? "production" : "development",
     target: `browserslist:${latestBuild ? "modern" : "legacy"}`,
-    devtool: isProdBuild ? "cheap-module-source-map" : "eval-cheap-module-source-map",
+    // For production, generate source maps for accurate stack traces without shipping the
+    // source itself. "cheap-module-source-map" would embed `sourcesContent` — the full
+    // pre-minification source of every module, HA frontend and node_modules alike — which was
+    // ~2/3 of the published wheel. `devtoolModuleFilenameTemplate` below points at GitHub
+    // instead. For development, generate "cheap" versions that map to original line numbers.
+    devtool: isProdBuild ? "nosources-source-map" : "eval-cheap-module-source-map",
     entry,
     node: false,
     module: {
@@ -279,6 +284,37 @@ const createRspackConfig = ({
       publicPath,
       // To silence warning in worker plugin
       globalObject: "self",
+      // Production source maps carry no sources, so point them elsewhere. This repo has two
+      // source roots: its own `src/` on XKNX/knx-frontend, and the homeassistant-frontend
+      // submodule, whose files live on home-assistant/frontend at the pinned commit (GitHub
+      // raw does not serve submodule contents, so they must NOT be addressed under this repo).
+      // Everything else — dependencies, generated files — gets a relative URL under a
+      // non-existent top directory: a clean source tree in dev tools, which stay happy getting
+      // 404s from valid requests.
+      ...Object.fromEntries(
+        ["", "Fallback"].map((v) => [
+          `devtool${v}ModuleFilenameTemplate`,
+          isProdBuild
+            ? (info) => {
+                const unknown = () => `/unknown${path.resolve("/", info.resourcePath)}`;
+                if (!path.isAbsolute(info.absoluteResourcePath) || !existsSync(info.resourcePath)) {
+                  return unknown();
+                }
+                const submodulePrefix = "./homeassistant-frontend/";
+                if (info.resourcePath.startsWith(`${submodulePrefix}src/`)) {
+                  const haURL = bundle.haSourceMapURL();
+                  return haURL
+                    ? new URL(info.resourcePath.slice(submodulePrefix.length), haURL).href
+                    : unknown();
+                }
+                if (info.resourcePath.startsWith("./src/")) {
+                  return new URL(info.resourcePath, bundle.sourceMapURL()).href;
+                }
+                return unknown();
+              }
+            : undefined,
+        ]),
+      ),
     },
     experiments: {
       outputModule: true,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "develop": "./script/develop",
     "build": "./script/build",
+    "build:size": "node build-scripts/report-output-size.cjs",
     "test": "vitest run --config vitest.config.ts",
     "test:watch": "vitest --config vitest.config.ts",
     "test:coverage": "vitest run --config vitest.config.ts --coverage",

--- a/src/util/empty.js
+++ b/src/util/empty.js
@@ -1,0 +1,3 @@
+/* empty file that we alias some files to that we don't want to include */
+
+export {}; // for Babel to treat as a module


### PR DESCRIPTION
The published wheel is **44.5 MB** and expands to **125 MB on disk**. It lands on every Home Assistant instance running the KNX integration, SD-card Raspberry Pis included.

Measured composition of `knx_frontend-2026.8.26.184052-py3-none-any.whl`:

| bucket | files | raw | in-wheel |
| --- | ---: | ---: | ---: |
| `*.js.map` | 1178 | 83.7 MB | 21.0 MB |
| `*.js` | 1182 | 26.3 MB | 8.0 MB |
| `*.js.gz` + `*.js.br` | 2366 | 14.4 MB | 14.4 MB |

**Source maps are 48% of the wheel and 67% of the installed size**, and two thirds of every map file is `sourcesContent` — the complete pre-minification source of every module, homeassistant-frontend and `node_modules` alike, embedded in the shipped artifact.

For scale, upstream ships more JS and a fraction of the map bytes:

| | `.js` shipped | maps | maps raw | `sourcesContent` |
| --- | ---: | ---: | ---: | ---: |
| `hass_frontend` 20260826.0 | 68.9 MB | 2328 | 60.3 MB | **0.46 MB** |
| `knx_frontend` 2026.8.26 | 26.3 MB | 1178 | 83.7 MB | **56.3 MB** |

`build-scripts/rspack.cjs` set `devtool: "cheap-module-source-map"` for production. Upstream uses `nosources-source-map` plus a `devtoolModuleFilenameTemplate` pointing at raw.githubusercontent.com; this fork copied the rspack config without that block.

## Changes

**Production maps carry mappings only.** `devtool` is now `nosources-source-map`, with module paths rewritten across two source roots: `src/` → `XKNX/knx-frontend` at `VERSION`, `homeassistant-frontend/src/` → `home-assistant/frontend` at the pinned submodule commit, everything else → `/unknown/…`.

The HA half has to address the **upstream** repo — GitHub raw does not serve submodule contents, so `XKNX/knx-frontend/<tag>/homeassistant-frontend/…` 404s on every HA frame (verified). The pin is read from the superproject tree rather than the submodule, so it survives CI's shallow `submodules: recursive` checkout where the submodule's tags are absent and `git describe` would fail. This is strictly better than upstream's own handling, which sends everything outside its source root to `/unknown/…`.

**hls.js and qr-scanner stubbed** via the existing `emptyPackages()` hook. The KNX panel renders no cameras but reaches HA components that do; hls.js alone was 1.3 MB. This needed `src/util/empty.js` created — the hook has been wired to a path that never existed in this repo, so it would have failed the build the moment it returned anything.

Only dynamic-import packages can be stubbed: a static import fails the build with `export 'default' was not found`, which is why `cropperjs` is excluded rather than giving the stub a default export and trading a build error for a silent runtime one. `barcode-detector` is excluded too — it calls `prepareZXingModule()` at the top level of `ha-qr-scanner.ts`.

**Output size reported after every build** (`yarn build:size`), in CI as well, so a regression like this is visible instead of going unnoticed for three years. `build-scripts/README.md` records why `devtool` must stay `nosources-*` and what to check before adding a stub.

## Result

```
installed   125.0 MB -> 64.4 MB  (-48%)
wheel        44.5 MB -> 30.4 MB  (-30%)
maps         83.7 MB -> 24.8 MB
```

## Verification

- **0 of 1172** maps contain `sourcesContent`
- HA source URLs resolve — six sampled at random, all 200 against `home-assistant/frontend/a406abf…/src/…`
- hls.js library body gone from every chunk (no `bufferAppend` / `hlsEventGeneric` / `levelSwitching`); remaining `mpegurl` hits are HA's own `ha-hls-player` / `ha-camera-stream` wrappers holding the MIME constant
- `yarn test` 268 passed / 17 files; eslint and prettier clean

## Not included

The `frontend_es5` build (~11.5 MB of the remaining 30.4) and trimming the lovelace/selector dependency blob were both considered and deliberately left out — echarts is wanted for future chart work, and `KnxHaSelector.selector` is the open `Selector` union filled by the backend, so stubbing selector types would be a latent runtime break with no build-time signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
