### PR TITLE
Add filter bucket for telegrams without DPT

### DIFF
--- a/src/features/group-monitor/controller/group-monitor-controller-dpt.test.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller-dpt.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { TelegramDict } from "../../../types/websocket";
-import { GroupMonitorController } from "./group-monitor-controller";
+import { GroupMonitorController, UNKNOWN_DPT_ID } from "./group-monitor-controller";
 import { getGroupMonitorInfo } from "../../../services/websocket.service";
 
 vi.mock("../../../services/websocket.service", () => ({
@@ -103,6 +103,36 @@ describe("GroupMonitorController - DPT Filtering & URL Syncing", () => {
       expect(result).toHaveLength(1);
       expect(result[0].sourceAddress).toBe("1.1.1");
       expect(result[0].dptId).toBe("1.001");
+    });
+  });
+
+  describe("Telegrams without DPT", () => {
+    it("should group telegrams without DPT under the unknown sentinel", async () => {
+      await injectTelegrams([
+        createMockTelegram({ dpt_main: 1, dpt_sub: 1, source: "1.1.1" }),
+        createMockTelegram({ source: "1.1.2" }),
+        createMockTelegram({ source: "1.1.3" }),
+      ]);
+
+      const { distinctValues } = controller.getFilteredTelegramsAndDistinctValues();
+
+      expect(distinctValues.dpt[UNKNOWN_DPT_ID]).toBeDefined();
+      expect(distinctValues.dpt[UNKNOWN_DPT_ID].totalCount).toBe(2);
+      expect(distinctValues.dpt["1.001"].totalCount).toBe(1);
+    });
+
+    it("should filter for telegrams without DPT", async () => {
+      await injectTelegrams([
+        createMockTelegram({ dpt_main: 1, dpt_sub: 1, source: "1.1.1" }),
+        createMockTelegram({ source: "1.1.2" }),
+      ]);
+
+      controller.setFilterFieldValue("dpt", [UNKNOWN_DPT_ID]);
+
+      const result = getFiltered();
+      expect(result).toHaveLength(1);
+      expect(result[0].sourceAddress).toBe("1.1.2");
+      expect(result[0].dptId).toBeNull();
     });
   });
 

--- a/src/features/group-monitor/controller/group-monitor-controller.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller.ts
@@ -30,6 +30,13 @@ export const FILTER_FIELDS: readonly FilterField[] = [
   "dpt",
 ] as const;
 
+/**
+ * Sentinel filter id for telegrams without a DPT (no project data or
+ * unknown group address). Kept URL-safe and distinct from real DPT ids,
+ * which are always numeric (e.g. "1.001").
+ */
+export const UNKNOWN_DPT_ID = "unknown";
+
 export type FilterMap = Record<FilterField, ReadonlySet<string>>;
 
 export interface DistinctValueInfo {
@@ -517,7 +524,7 @@ export class GroupMonitorController implements ReactiveController {
         destination: telegram.destinationAddress,
         direction: telegram.direction,
         telegramtype: telegram.type,
-        dpt: telegram.dptId,
+        dpt: telegram.dptId ?? UNKNOWN_DPT_ID,
       };
 
       return values.includes(fieldMap[field] || "");
@@ -1007,7 +1014,9 @@ export class GroupMonitorController implements ReactiveController {
       case "telegramtype":
         return { id: telegram.type, name: "" };
       case "dpt":
-        if (!telegram.dptId) return null;
+        // Telegrams without DPT information are grouped under a sentinel id so
+        // they remain filterable; the display name is resolved by the view.
+        if (!telegram.dptId) return { id: UNKNOWN_DPT_ID, name: "" };
         return { id: telegram.dptId, name: telegram.dpt || telegram.dptId };
       default:
         return null;

--- a/src/features/group-monitor/views/group-monitor-view.ts
+++ b/src/features/group-monitor/views/group-monitor-view.ts
@@ -35,7 +35,7 @@ import type { TelegramInfoDialogParams } from "../dialogs/telegram-info-dialog";
 import { formatTimeWithMilliseconds, formatTimeDelta, formatDate } from "../../../utils/format";
 import type { TelegramRow, TelegramRowKeys } from "../types/telegram-row";
 import type { ToggleFilterEvent } from "../../../components/data-table/cell/knx-table-cell-filterable";
-import { GroupMonitorController } from "../controller/group-monitor-controller";
+import { GroupMonitorController, UNKNOWN_DPT_ID } from "../controller/group-monitor-controller";
 import type {
   DistinctValueInfo,
   DistinctValues,
@@ -118,7 +118,7 @@ export function migrateStoredColumns(stored: StoredColumns | undefined): StoredC
  * - `?destination=1/2/3,4/5/6` - Filter by destination addresses (comma-separated)
  * - `?direction=Incoming` - Filter by telegram direction (comma-separated)
  * - `?telegramtype=GroupValueWrite,GroupValueRead` - Filter by telegram types (comma-separated)
- * - `?dpt=1.001,5.001` - Filter by Data Point Types (comma-separated)
+ * - `?dpt=1.001,5.001` - Filter by Data Point Types (comma-separated); `unknown` matches telegrams without DPT
  * - `?timedelta_before=100` - Include telegrams up to 100ms before a match (only applies when list filters are active)
  * - `?timedelta_after=100` - Include telegrams up to 100ms after a match (only applies when list filters are active)
  *
@@ -226,7 +226,15 @@ export class KNXGroupMonitor extends LitElement {
       }
     }
 
-    // 2. Override/update with actual telegram distinct values
+    // 2. Always offer the "unknown" bucket for telegrams without DPT information
+    dptMap[UNKNOWN_DPT_ID] = {
+      id: UNKNOWN_DPT_ID,
+      name: "",
+      totalCount: 0,
+      filteredCount: 0,
+    };
+
+    // 3. Override/update with actual telegram distinct values
     for (const info of Object.values(distinctValues.dpt)) {
       const dptId = info.id;
       if (dptMap[dptId]) {
@@ -502,7 +510,8 @@ export class KNXGroupMonitor extends LitElement {
         sortAscendingText: this.knx.localize("telegram_filter_sort_ascending"),
         sortDescendingText: this.knx.localize("telegram_filter_sort_descending"),
         sortDefaultDirection: "asc",
-        mapper: (item: DistinctValueInfo) => item.id,
+        mapper: (item: DistinctValueInfo) =>
+          item.id === UNKNOWN_DPT_ID ? this.hass.localize("state.default.unknown") : item.id,
       },
       secondaryField: {
         fieldName: this.knx.localize("telegram_filter_dpt_sort_by_secondaryText"),


### PR DESCRIPTION
## Proposed change

Telegrams without DPT information were skipped when the group monitor built its distinct filter values, so they were neither countable nor filterable - and every one of them logged `Unknown field for distinct values: dpt`, once per telegram on every buffer load.

Group them under a stable `unknown` sentinel id instead, so they behave like any other DPT value: they get counted, they show up in the DPT filter as a localized "Unknown" entry (`state.default.unknown`), and they can be selected - including via `?dpt=unknown` in the URL. The id itself stays untranslated so URLs survive language changes.

Telegrams end up without DPT whenever the backend can't provide one: no project loaded, group addresses missing from the project, and - until home-assistant/core#180390 - `GroupValueRead` and undecoded DataSecure telegrams.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Related core PR: home-assistant/core#180390 - reports the group address DPT for telegrams that carry nothing to decode, which removes the largest source of "unknown" entries.

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] Tests have been added to verify that the new code works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
