### PR TITLE
Report build output size in the CI check list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    # Surfaced by the `size` job below, whose name is this string.
+    outputs:
+      size: ${{ steps.size.outputs.summary }}
     steps:
       - name: Check out files from GitHub
         uses: actions/checkout@v7
@@ -88,4 +91,21 @@ jobs:
         run: yarn build
 
       - name: Report output size
-        run: yarn run build:size
+        id: size
+        run: |
+          yarn run build:size --markdown .build-size.md
+          cat .build-size.md >> "$GITHUB_STEP_SUMMARY"
+
+  # The shipped wheel is just knx_frontend/ zipped up, so its size is what every Home Assistant
+  # install pays for — and it is easy to inflate by accident. Put it in the check list where it
+  # cannot be missed. A job's own name is fixed before it runs and cannot report its result, but
+  # `needs` is allowed in `jobs.<id>.name`, so a downstream job can be *named* after the number:
+  #   CI / Size: 30.44 MB download, 64.39 MB installed (pull_request)
+  size:
+    # Quoted: an unquoted value containing ": " is not valid YAML here.
+    name: "Size: ${{ needs.build.outputs.size }}"
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build output size
+        run: echo "${{ needs.build.outputs.size }}"

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ yarn-error.log
 
 result.md
 
+# Build size report (CI)
+.build-size.md
+
 # Test Coverage files
 test/coverage/
 

--- a/build-scripts/report-output-size.cjs
+++ b/build-scripts/report-output-size.cjs
@@ -1,15 +1,25 @@
 /* global require, process, __dirname */
 // Report the size of the built panel, broken down by file type.
 //
-// The shipped wheel is just `knx_frontend/` zipped up, so this is the number users pay for on
-// every install. It is easy to inflate by accident — a `devtool` setting that embeds
-// `sourcesContent` once made source maps 48% of the wheel and went unnoticed for three years —
-// so print the breakdown on every build and let it show up in CI logs and PR diffs.
+// The shipped wheel is just `knx_frontend/` zipped up, so this is the number every Home
+// Assistant install pays for. It is easy to inflate by accident — a `devtool` setting that
+// embedded `sourcesContent` once made source maps 48% of the wheel and 67% of the installed
+// size, and went unnoticed for three years — so measure it on every build and surface it on
+// the PR rather than burying it in a log.
 //
-// Usage: node build-scripts/report-output-size.cjs
+// Two numbers are reported per bucket:
+//   installed - bytes on disk, what the wheel expands to
+//   download  - the same bytes deflated, which is what the wheel itself weighs
+//
+// Usage:
+//   node build-scripts/report-output-size.cjs [--markdown <path>]
+//
+// When GITHUB_OUTPUT is set, a one-line `summary=` is written for use as a commit status
+// description, so the size shows up in the PR check list.
 
 const fs = require("fs");
 const path = require("path");
+const zlib = require("zlib");
 const paths = require("./paths.cjs");
 
 const CATEGORIES = [
@@ -25,12 +35,20 @@ const categorize = (file) => CATEGORIES.find(([, test]) => test(file))?.[0] ?? "
 const walk = function* (dir) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
+    if (entry.name === "__pycache__") {
+      continue;
+    }
     if (entry.isDirectory()) {
       yield* walk(full);
     } else if (entry.isFile()) {
       yield full;
     }
   }
+};
+
+const arg = (name) => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : process.argv[i + 1];
 };
 
 const mb = (bytes) => `${(bytes / 1048576).toFixed(2)} MB`;
@@ -41,31 +59,61 @@ if (!fs.existsSync(root)) {
   process.exit(1);
 }
 
-const totals = new Map();
-let grandTotal = 0;
-let fileCount = 0;
+// Measure. `download` deflates each file the way the wheel does; already-compressed .gz/.br
+// files come back roughly unchanged, which is exactly how they land in the wheel too.
+const buckets = {};
+let files = 0;
+let installed = 0;
+let download = 0;
 for (const file of walk(root)) {
   const rel = path.relative(root, file);
   const build = rel.includes(path.sep) ? rel.split(path.sep)[0] : "(root)";
-  const key = `${build}\t${categorize(file)}`;
-  const size = fs.statSync(file).size;
-  const entry = totals.get(key) ?? { count: 0, size: 0 };
-  entry.count += 1;
-  entry.size += size;
-  totals.set(key, entry);
-  grandTotal += size;
-  fileCount += 1;
+  const key = `${build} ${categorize(file)}`;
+  const data = fs.readFileSync(file);
+  const compressed = zlib.deflateSync(data, { level: 6 }).length;
+  buckets[key] ??= { files: 0, installed: 0, download: 0 };
+  buckets[key].files += 1;
+  buckets[key].installed += data.length;
+  buckets[key].download += compressed;
+  files += 1;
+  installed += data.length;
+  download += compressed;
 }
 
-const rows = [...totals.entries()]
-  .map(([key, v]) => ({ ...v, build: key.split("\t")[0], ext: key.split("\t")[1] }))
-  .sort((a, b) => b.size - a.size);
+const rows = Object.entries(buckets)
+  .map(([key, v]) => ({ ...v, key }))
+  .filter((r) => r.installed >= 1024)
+  .sort((a, b) => b.download - a.download);
 
-console.log(`\nBuild output: ${mb(grandTotal)} across ${fileCount} files (${root})\n`);
-console.log(`${"build".padEnd(18)}${"type".padEnd(16)}${"files".padStart(7)}${"size".padStart(12)}`);
+console.log(`\nBuild output: ${mb(installed)} installed, ${mb(download)} download (${files} files)\n`);
+console.log(`${"bucket".padEnd(28)}${"files".padStart(7)}${"installed".padStart(12)}${"download".padStart(12)}`);
 for (const r of rows) {
   console.log(
-    `${r.build.padEnd(18)}${r.ext.padEnd(16)}${String(r.count).padStart(7)}${mb(r.size).padStart(12)}`,
+    `${r.key.padEnd(28)}${String(r.files).padStart(7)}${mb(r.installed).padStart(12)}${mb(r.download).padStart(12)}`,
   );
 }
-console.log(`${"TOTAL".padEnd(34)}${String(fileCount).padStart(7)}${mb(grandTotal).padStart(12)}\n`);
+console.log(`${"TOTAL".padEnd(28)}${String(files).padStart(7)}${mb(installed).padStart(12)}${mb(download).padStart(12)}`);
+console.log();
+
+// One-line summary for a commit status description (max 140 chars)
+const summary = `${mb(download)} download, ${mb(installed)} installed`;
+console.log(summary);
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `summary=${summary}\n`);
+}
+
+// Breakdown for the CI job summary page
+const markdownPath = arg("markdown");
+if (markdownPath) {
+  const lines = [
+    "### Build size",
+    "",
+    "| bucket | files | installed | download |",
+    "| --- | ---: | ---: | ---: |",
+    ...rows.map((r) => `| \`${r.key}\` | ${r.files} | ${mb(r.installed)} | ${mb(r.download)} |`),
+    `| **total** | **${files}** | **${mb(installed)}** | **${mb(download)}** |`,
+    "",
+    "`installed` is what the wheel expands to on disk; `download` is the wheel itself.",
+  ];
+  fs.writeFileSync(markdownPath, `${lines.join("\n")}\n`);
+}


### PR DESCRIPTION
Follow-up to #441. That PR cut the wheel from 44.5 MB to ~30 MB and the installed size from 125 MB to 64 MB. The regression it fixed had been there for three years because nothing ever surfaced the number — this makes it visible.

The size shows up as its own line in the check list:

```
CI / Size: 30.44 MB download, 64.39 MB installed (pull_request)   Successful in 4s
```

A job's own name is fixed before it runs, so `Build` can't report its own result. But `needs` is [an allowed context](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability) in `jobs.<job_id>.name`, so a downstream job can be *named* after the number the build produced:

```yaml
  build:
    outputs:
      size: ${{ steps.size.outputs.summary }}
  size:
    name: "Size: ${{ needs.build.outputs.size }}"
    needs: build
```

No extra permissions, no API calls, no fork carve-out — just a job name.

The per-bucket breakdown goes to the job summary:

| bucket | files | installed | download |
| --- | ---: | ---: | ---: |
| `frontend_es5 .js.map` | 597 | 12.77 MB | 4.44 MB |
| `frontend_latest .js.map` | 575 | 12.07 MB | 4.24 MB |
| `frontend_es5 .js` | 601 | 13.00 MB | 3.95 MB |
| … | | | |
| **total** | **4940** | **64.39 MB** | **30.44 MB** |

`installed` is what the wheel expands to on disk; `download` deflates each file the way the wheel does, so it tracks the wheel's own weight. Already-compressed `.gz`/`.br` files come back roughly unchanged, which is how they land in the wheel too.

Sizes are absolute — nothing is cached and no cross-run comparison is made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

