### PR TITLE
Use braces icon for the YAML mode toggle

### DIFF
--- a/src/views/entities_create.ts
+++ b/src/views/entities_create.ts
@@ -1,4 +1,4 @@
-import { mdiPlus, mdiFloppy, mdiPlaylistEdit } from "@mdi/js";
+import { mdiPlus, mdiFloppy, mdiCodeBraces, mdiPlaylistEdit } from "@mdi/js";
 import deepClone from "deep-clone-simple";
 import type { TemplateResult, PropertyValues } from "lit";
 import { LitElement, html, css, nothing } from "lit";
@@ -354,7 +354,7 @@ export class KNXCreateEntity extends DirtyStateProviderMixin<EntityData>()(
             ? "ui.panel.config.automation.editor.edit_yaml"
             : "ui.panel.config.automation.editor.edit_ui",
         )}
-        .path=${mdiPlaylistEdit}
+        .path=${this._mode === "gui" ? mdiCodeBraces : mdiPlaylistEdit}
         @click=${this._toggleMode}
       ></ha-icon-button>
       <div class="content">

--- a/src/views/expose_create.ts
+++ b/src/views/expose_create.ts
@@ -1,4 +1,11 @@
-import { mdiDelete, mdiFileDocumentEdit, mdiPlus, mdiFloppy, mdiPlaylistEdit } from "@mdi/js";
+import {
+  mdiDelete,
+  mdiFileDocumentEdit,
+  mdiPlus,
+  mdiFloppy,
+  mdiCodeBraces,
+  mdiPlaylistEdit,
+} from "@mdi/js";
 import deepClone from "deep-clone-simple";
 import type { TemplateResult, PropertyValues } from "lit";
 import { LitElement, html, css, nothing } from "lit";
@@ -334,7 +341,7 @@ export class KNXCreateExpose extends DirtyStateProviderMixin<ExposeConfigData>()
               ? "ui.panel.config.automation.editor.edit_yaml"
               : "ui.panel.config.automation.editor.edit_ui",
           )}
-          .path=${mdiPlaylistEdit}
+          .path=${this._mode === "gui" ? mdiCodeBraces : mdiPlaylistEdit}
           @click=${this._toggleMode}
         ></ha-icon-button>
         ${this.narrow && this._mode === "gui" ? this._renderNotesDialog() : nothing}


### PR DESCRIPTION
Replaces the YAML mode toolbar icon in the entity create/edit and expose create/edit views.

- GUI mode → `mdiCodeBraces` (`{}`), the same icon the more-info dialog uses for its details YAML toggle
- YAML mode → `mdiPlaylistEdit`, so switching back to the visual editor reads as its own direction

Labels were already mode-dependent and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)