### PR TITLE
Stub out what the KNX panel does not use: 70.0 MB -> 54.9 MB installed

### DIFF
--- a/build-scripts/README.md
+++ b/build-scripts/README.md
@@ -68,7 +68,7 @@ wheel — as lazy chunks nobody downloads, but on disk all the same.
 
 [stubs.cjs](stubs.cjs) is the list of modules replaced with a stub for that reason, one entry
 per library, each with the reason it is there. The replacements live in
-[../src/stubs](../src/stubs) and every one of them logs
+[../src/stubs](../src/stubs) and every one of them logs, as a console error,
 
 ```
 [KNX] "<entry name>" is stubbed out in this build ...

--- a/build-scripts/README.md
+++ b/build-scripts/README.md
@@ -60,18 +60,29 @@ GitHub instead, across two source roots:
   contents, so `XKNX/knx-frontend/<tag>/homeassistant-frontend/…` would 404 on every HA frame.
 - everything else → `/unknown/…`, which dev tools request and cheerfully 404 on.
 
-### Camera stubs
+### Stubs
 
-`emptyPackages()` in [bundle.cjs](bundle.cjs) replaces hls.js and qr-scanner with an empty
-module. The KNX panel renders no cameras, but it reaches HA components that do, and hls.js alone
-was 1.3 MB of the wheel.
+The panel is built from the whole homeassistant-frontend source tree, so it inherits every
+dependency HA has, reachable from the KNX panel or not. Unreachable code still lands in the
+wheel — as lazy chunks nobody downloads, but on disk all the same.
 
-Only packages behind a **dynamic** import can be stubbed. A static `import X from "pkg"` fails
-the build with `export 'default' was not found`, which is why cropperjs is not on the list — do
-not "fix" that by giving [../src/util/empty.js](../src/util/empty.js) a default export, as that
-trades a build error for a silent runtime one. Also check the package is not used at module top
-level (`barcode-detector` is excluded for that reason: an empty module would throw when
-ha-qr-scanner is evaluated rather than when it is used).
+[stubs.cjs](stubs.cjs) is the list of modules replaced with a stub for that reason, one entry
+per library, each with the reason it is there. The replacements live in
+[../src/stubs](../src/stubs) and every one of them logs
+
+```
+[KNX] "<entry name>" is stubbed out in this build ...
+```
+
+the moment it is actually reached, so a feature that quietly does nothing points at the entry
+that removed it. Deleting the entry is all it takes to get the real module back.
+
+A stub is a real module, not an empty file: it has to carry the value exports its consumers
+import (type-only imports are erased and need nothing), or the build fails with
+`export 'X' was not found`. That is the constraint that used to rule out anything behind a
+static `import X from "pkg"` — with a named stub file it no longer does, as long as the shape
+it exports makes the consumer degrade on its own (`isSupported: () => false`) instead of
+throwing somewhere deep inside it.
 
 Point `require.resolve` at the entry file rspack actually picks: `main` is often the CommonJS
 build while the bundle gets `browser` or `module`, and a stub aimed at the wrong file silently

--- a/build-scripts/bundle.cjs
+++ b/build-scripts/bundle.cjs
@@ -43,41 +43,6 @@ module.exports.haSourceMapURL = () => {
 // Files from NPM Packages that should not be imported
 module.exports.ignorePackages = () => [];
 
-// Files from NPM packages that we should replace with empty file.
-//
-// The KNX panel renders no cameras, no media browser and no image uploads, so the
-// camera/video/image-processing dependencies HA pulls in are dead weight here — hls.js alone
-// was 1.3 MB of the published wheel.
-//
-// Only packages reached through a *dynamic* import can be stubbed: a static `import X from`
-// fails the build outright with "export 'default' was not found" against the empty module.
-// That rules out "cropperjs" (image-cropper-dialog imports it statically, and it is only
-// ~160 KB). Also excluded: "barcode-detector", which calls prepareZXingModule() at the top
-// level of ha-qr-scanner.ts, so an empty module would throw when that module is evaluated
-// rather than when it is used; and "node-vibrant", at only ~30 KB.
-//
-// See the camera stubs note in build-scripts/README.md before adding to this list.
-module.exports.emptyPackages = () =>
-  [
-    // HTTP Live Streaming player, dynamically imported by ha-hls-player for camera streams.
-    require.resolve("hls.js/dist/hls.light.mjs"),
-    // Camera-based QR code scanner, dynamically imported by ha-qr-scanner. Resolve the exact
-    // entry rspack picks (the "module" field), not the bare package — require.resolve() would
-    // give the CommonJS "main" (qr-scanner.umd.min.js), which is never the file in the bundle.
-    require.resolve("qr-scanner/qr-scanner.min.js"),
-
-    // Icons in landingpage conflict with icons in HA so we don't load.
-    // ... for KNX we seem to need it - probably due to iframe.
-    //
-    //   require.resolve(
-    //     path.resolve(paths.root_dir, "homeassistant-frontend/src/components/ha-icon.ts"),
-    //   ),
-    //
-    //   require.resolve(
-    //     path.resolve(paths.root_dir, "homeassistant-frontend/src/components/ha-icon-picker.ts"),
-    //   ),
-  ].filter(Boolean);
-
 module.exports.definedVars = ({ isProdBuild, latestBuild, defineOverlay }) => ({
   __DEV__: !isProdBuild,
   __BUILD__: JSON.stringify(latestBuild ? "latest" : "es5"),

--- a/build-scripts/rspack.cjs
+++ b/build-scripts/rspack.cjs
@@ -14,6 +14,7 @@ const log = require("fancy-log");
 const SafeWebpackBar = require("./safe-webpackbar.cjs");
 const paths = require("./paths.cjs");
 const bundle = require("./bundle.cjs");
+const stubs = require("./stubs.cjs");
 
 class LogStartCompilePlugin {
   ignoredFirst = false;
@@ -184,12 +185,14 @@ const createRspackConfig = ({
           return ignorePackages.some((toIgnorePath) => fullPath.startsWith(toIgnorePath));
         },
       }),
-      bundle.emptyPackages().length
-        ? new rspack.NormalModuleReplacementPlugin(
-            new RegExp(bundle.emptyPackages().join("|")),
-            path.resolve(paths.root_dir, "src/util/empty.js"),
-          )
-        : false,
+      // Modules the KNX panel does not need, swapped for a stub that says so out loud.
+      // The list, and what to do when one of them turns out to be needed after all, is in
+      // build-scripts/stubs.cjs.
+      ...stubs
+        .moduleReplacements()
+        .map(
+          ({ test, replacement }) => new rspack.NormalModuleReplacementPlugin(test, replacement),
+        ),
       // core-js ships a Node-only helper that evaluates
       // `Function('return require("...")')()` when its runtime environment
       // detection mis-classifies the page as Node. That produces a

--- a/build-scripts/stubs.cjs
+++ b/build-scripts/stubs.cjs
@@ -91,6 +91,17 @@ const stubs = [
     test: haDirectory("resources/echarts"),
     replacement: stub("echarts.ts"),
   },
+  {
+    name: "calendars",
+    why: "<ha-full-calendar> and <ha-schedule-form> are the only modules that reach @fullcalendar, and through it luxon and rrule. The KNX panel shows no calendars and edits no schedule helpers. Neither module has a value export — both are only ever imported for the element they define.",
+    test: exactly(
+      ...ha(
+        "panels/calendar/ha-full-calendar.ts",
+        "panels/config/helpers/forms/ha-schedule-form.ts",
+      ),
+    ),
+    replacement: stub("calendar.ts"),
+  },
 ];
 
 module.exports.stubs = stubs;

--- a/build-scripts/stubs.cjs
+++ b/build-scripts/stubs.cjs
@@ -120,6 +120,13 @@ const stubs = [
     ),
     replacement: stub("media-player.ts"),
   },
+  {
+    name: "cropperjs",
+    why: "Image cropper, imported statically by image-cropper-dialog for picture uploads the KNX panel never makes. This is the one the old empty-file mechanism could not take: a static default import needs something to import.",
+    // `browser` is the entry rspack picks here; `main` (cropper.common.js) never appears.
+    test: exactly(npm("cropperjs/dist/cropper.js")),
+    replacement: stub("cropperjs.ts"),
+  },
 ];
 
 module.exports.stubs = stubs;

--- a/build-scripts/stubs.cjs
+++ b/build-scripts/stubs.cjs
@@ -76,6 +76,12 @@ const stubs = [
     test: exactly(npm("qr-scanner/qr-scanner.min.js")),
     replacement: stub("qr-scanner.ts"),
   },
+  {
+    name: "maps",
+    why: "<ha-map> and <ha-locations-editor> are the only modules that reach leaflet, leaflet-draw, leaflet.markercluster and maplibre-gl — 2 MB of map renderer for a panel that draws no maps.",
+    test: exactly(...ha("components/map/ha-map.ts", "components/map/ha-locations-editor.ts")),
+    replacement: stub("ha-map.ts"),
+  },
 ];
 
 module.exports.stubs = stubs;

--- a/build-scripts/stubs.cjs
+++ b/build-scripts/stubs.cjs
@@ -102,6 +102,24 @@ const stubs = [
     ),
     replacement: stub("calendar.ts"),
   },
+  {
+    name: "media browser",
+    why: "The media browse dialogs and the component behind them, plus the virtualizer's grid layout, whose only user ha-media-player-browse is (the virtualizer itself stays — ha-data-table renders one). KNX has no media_player entities, so nothing in the panel can open one. Small change on its own — kept because it is one console warning away from being obvious if that ever stops being true.",
+    test: exactly(
+      ...ha(
+        "components/media-player/dialog-join-media-players.ts",
+        "components/media-player/dialog-media-manage.ts",
+        "components/media-player/dialog-media-player-browse.ts",
+        "components/media-player/ha-browse-media-manual.ts",
+        "components/media-player/ha-browse-media-tts.ts",
+        "components/media-player/ha-media-browser-thumbnail.ts",
+        "components/media-player/ha-media-manage-button.ts",
+        "components/media-player/ha-media-player-browse.ts",
+        "components/media-player/ha-media-upload-button.ts",
+      ),
+    ),
+    replacement: stub("media-player.ts"),
+  },
 ];
 
 module.exports.stubs = stubs;

--- a/build-scripts/stubs.cjs
+++ b/build-scripts/stubs.cjs
@@ -54,6 +54,9 @@ const ha = (...relativePaths) =>
     path.resolve(paths.root_dir, "homeassistant-frontend/src", relative),
   );
 
+/** Every module inside a homeassistant-frontend directory, relative to its `src/`. */
+const haDirectory = (relative) => new RegExp(`^${escapeRegExp(...ha(relative))}[\\\\/].*\\.ts$`);
+
 /** Our replacement, in `src/stubs/`. */
 const stub = (file) => path.resolve(paths.root_dir, "src/stubs", file);
 
@@ -81,6 +84,12 @@ const stubs = [
     why: "<ha-map> and <ha-locations-editor> are the only modules that reach leaflet, leaflet-draw, leaflet.markercluster and maplibre-gl — 2 MB of map renderer for a panel that draws no maps.",
     test: exactly(...ha("components/map/ha-map.ts", "components/map/ha-locations-editor.ts")),
     replacement: stub("ha-map.ts"),
+  },
+  {
+    name: "echarts",
+    why: "resources/echarts is the only door echarts, zrender and the chart2music extension come in through — 2 MB of chart engine for a panel that draws no charts. The chart components under components/chart stay: they are small, other modules import helpers out of them, and with no engine behind them they draw nothing.",
+    test: haDirectory("resources/echarts"),
+    replacement: stub("echarts.ts"),
   },
 ];
 

--- a/build-scripts/stubs.cjs
+++ b/build-scripts/stubs.cjs
@@ -9,7 +9,8 @@
  *
  * ── If something in the panel is missing or dead, look here first ──────────────────────────
  *
- * Every stub says so on the console the moment it is reached:
+ * Every stub reports itself on the console — as an error, not a warning — the moment it is
+ * reached:
  *
  *     [KNX] "leaflet maps" is stubbed out in this build ...
  *
@@ -25,7 +26,7 @@
  *     "export 'X' was not found". Type-only imports are erased and need nothing.
  *   - Prefer a shape that makes the consumer degrade on its own (`isSupported: () => false`)
  *     over one that throws somewhere deep inside it.
- *   - Warn from the point that means "actually used": module scope for something behind a
+ *   - Report from the point that means "actually used": module scope for something behind a
  *     dynamic import, `connectedCallback` for a custom element (its module is often
  *     evaluated eagerly by a static import that never renders anything).
  *   - Check what rspack really resolves: a package's `main` is often the CommonJS build while

--- a/build-scripts/stubs.cjs
+++ b/build-scripts/stubs.cjs
@@ -1,0 +1,85 @@
+/* Modules the KNX panel replaces with a stub at build time.
+ *
+ * The panel is built from the full homeassistant-frontend source tree, so it inherits every
+ * dependency HA has — camera players, map renderers, chart engines — whether or not the KNX
+ * panel can reach them. Unreachable code still ships: rspack emits it as lazy chunks that no
+ * KNX user ever downloads, but `knx_frontend/` is zipped into the wheel as-is, so every Home
+ * Assistant install pays for it on disk. Replacing the module that pulls a library in drops
+ * the whole subtree behind it.
+ *
+ * ── If something in the panel is missing or dead, look here first ──────────────────────────
+ *
+ * Every stub says so on the console the moment it is reached:
+ *
+ *     [KNX] "leaflet maps" is stubbed out in this build ...
+ *
+ * The quoted name is the `name` of an entry below. To get the real module back, delete that
+ * entry and rebuild — nothing else references it.
+ *
+ * ── Adding an entry ───────────────────────────────────────────────────────────────────────
+ *
+ * `test` is matched against the *resolved absolute path*, so use the helpers below rather
+ * than hand-writing a regex. The replacement must be a real module, not an empty file:
+ *
+ *   - Every value export its consumers use must exist, or the build fails with
+ *     "export 'X' was not found". Type-only imports are erased and need nothing.
+ *   - Prefer a shape that makes the consumer degrade on its own (`isSupported: () => false`)
+ *     over one that throws somewhere deep inside it.
+ *   - Warn from the point that means "actually used": module scope for something behind a
+ *     dynamic import, `connectedCallback` for a custom element (its module is often
+ *     evaluated eagerly by a static import that never renders anything).
+ *   - Check what rspack really resolves: a package's `main` is often the CommonJS build while
+ *     the bundle gets `browser` or `module`, and a stub aimed at the wrong file matches
+ *     nothing at all — silently.
+ *
+ * Verify with `yarn build && yarn build:size`, and confirm the library is gone rather than
+ * merely moved: `grep -rl <marker> knx_frontend/frontend_latest` should come back empty.
+ */
+
+const path = require("path");
+const paths = require("./paths.cjs");
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/** Matches exactly these absolute paths, and nothing else. */
+const exactly = (...absolutePaths) =>
+  new RegExp(`^(?:${absolutePaths.map(escapeRegExp).join("|")})$`);
+
+/** An npm package entry, resolved the way the bundler resolves it. */
+const npm = (request) => require.resolve(request);
+
+/** Modules inside the homeassistant-frontend submodule, relative to its `src/`. */
+const ha = (...relativePaths) =>
+  relativePaths.map((relative) =>
+    path.resolve(paths.root_dir, "homeassistant-frontend/src", relative),
+  );
+
+/** Our replacement, in `src/stubs/`. */
+const stub = (file) => path.resolve(paths.root_dir, "src/stubs", file);
+
+/**
+ * @type {{ name: string, why: string, test: RegExp, replacement: string }[]}
+ */
+const stubs = [
+  {
+    name: "hls.js",
+    why: "HTTP Live Streaming player, dynamically imported by ha-hls-player for camera streams. The KNX panel renders no cameras; this alone was 1.3 MB of the wheel.",
+    // Resolve the exact entry ha-hls-player imports, not the bare package.
+    test: exactly(npm("hls.js/dist/hls.light.mjs")),
+    replacement: stub("hls.ts"),
+  },
+  {
+    name: "qr-scanner",
+    why: "Camera-based QR code scanner, dynamically imported by ha-qr-scanner. Nothing in the KNX panel scans QR codes.",
+    // The "module" entry is the one in the bundle; require.resolve() would give the
+    // CommonJS "main" (qr-scanner.umd.min.js), which never appears in it.
+    test: exactly(npm("qr-scanner/qr-scanner.min.js")),
+    replacement: stub("qr-scanner.ts"),
+  },
+];
+
+module.exports.stubs = stubs;
+
+/** `[{ test, replacement }]` for rspack's NormalModuleReplacementPlugin. */
+module.exports.moduleReplacements = () =>
+  stubs.map(({ test, replacement }) => ({ test, replacement }));

--- a/src/stubs/calendar.ts
+++ b/src/stubs/calendar.ts
@@ -5,11 +5,11 @@
 // helpers. Neither module has a value export; both are only ever imported for their side
 // effect of defining an element, so registering an empty one is the whole stub.
 
-import { warnStubbed } from "./stub-warning";
+import { reportStubbed } from "./stub-report";
 
 class StubbedCalendarElement extends HTMLElement {
   public connectedCallback(): void {
-    warnStubbed("calendars", `showing <${this.localName}>`);
+    reportStubbed("calendars", `showing <${this.localName}>`);
   }
 }
 

--- a/src/stubs/calendar.ts
+++ b/src/stubs/calendar.ts
@@ -1,0 +1,20 @@
+// Stub for HA's <ha-full-calendar> and <ha-schedule-form> — see build-scripts/stubs.cjs.
+//
+// The two of them are the only modules that reach @fullcalendar (and, through it, luxon)
+// and the recurrence editor's rrule. The KNX panel shows no calendars and edits no schedule
+// helpers. Neither module has a value export; both are only ever imported for their side
+// effect of defining an element, so registering an empty one is the whole stub.
+
+import { warnStubbed } from "./stub-warning";
+
+class StubbedCalendarElement extends HTMLElement {
+  public connectedCallback(): void {
+    warnStubbed("calendars", `showing <${this.localName}>`);
+  }
+}
+
+for (const tagName of ["ha-full-calendar", "ha-schedule-form"]) {
+  if (!customElements.get(tagName)) {
+    customElements.define(tagName, class extends StubbedCalendarElement {});
+  }
+}

--- a/src/stubs/cropperjs.ts
+++ b/src/stubs/cropperjs.ts
@@ -4,11 +4,11 @@
 // the KNX panel never does. The methods the dialog calls are all here and all no-ops, so
 // the dialog opens on an uncropped image instead of throwing its way through a render.
 
-import { warnStubbed } from "./stub-warning";
+import { reportStubbed } from "./stub-report";
 
 export default class Cropper {
   public constructor() {
-    warnStubbed("cropperjs", "cropping an uploaded image");
+    reportStubbed("cropperjs", "cropping an uploaded image");
   }
 
   public getData(): Record<string, never> {

--- a/src/stubs/cropperjs.ts
+++ b/src/stubs/cropperjs.ts
@@ -1,0 +1,33 @@
+// Stub for cropperjs — see build-scripts/stubs.cjs.
+//
+// image-cropper-dialog imports it statically to crop a picture before uploading it, which
+// the KNX panel never does. The methods the dialog calls are all here and all no-ops, so
+// the dialog opens on an uncropped image instead of throwing its way through a render.
+
+import { warnStubbed } from "./stub-warning";
+
+export default class Cropper {
+  public constructor() {
+    warnStubbed("cropperjs", "cropping an uploaded image");
+  }
+
+  public getData(): Record<string, never> {
+    return {};
+  }
+
+  public getImageData(): Record<string, never> {
+    return {};
+  }
+
+  public getCroppedCanvas(): HTMLCanvasElement {
+    return document.createElement("canvas");
+  }
+
+  public replace(): void {
+    // no-op
+  }
+
+  public destroy(): void {
+    // no-op
+  }
+}

--- a/src/stubs/echarts.ts
+++ b/src/stubs/echarts.ts
@@ -11,9 +11,9 @@
 // property with a function. Everything it returns is undefined, which is where a chart that
 // really is needed will fail — right after the warning below says why.
 
-import { warnStubbed } from "./stub-warning";
+import { reportStubbed } from "./stub-report";
 
-warnStubbed("echarts", "drawing charts and graphs");
+reportStubbed("echarts", "drawing charts and graphs");
 
 const noop = (): undefined => undefined;
 

--- a/src/stubs/echarts.ts
+++ b/src/stubs/echarts.ts
@@ -1,0 +1,25 @@
+// Stub for HA's echarts wiring — see build-scripts/stubs.cjs.
+//
+// Everything under homeassistant-frontend/src/resources/echarts is replaced by this file:
+// that directory is the only door echarts, zrender and the chart2music extension come in
+// through. The chart components themselves stay — they are small, other modules import
+// helpers out of them, and without an engine they simply draw nothing.
+//
+// ha-chart-base reaches the engine through `(await import(...)).default` and then calls
+// `.use()`, `.registerTheme()` and `.init()` on it, and the sankey module's default export
+// is called as a function, so the default export here has to be callable *and* answer any
+// property with a function. Everything it returns is undefined, which is where a chart that
+// really is needed will fail — right after the warning below says why.
+
+import { warnStubbed } from "./stub-warning";
+
+warnStubbed("echarts", "drawing charts and graphs");
+
+const noop = (): undefined => undefined;
+
+export default new Proxy(noop, { get: () => noop });
+
+// Used by the energy cards to build gradients.
+export const LinearGradient = class StubbedLinearGradient {
+  public readonly stubbed = true;
+};

--- a/src/stubs/ha-map.ts
+++ b/src/stubs/ha-map.ts
@@ -7,11 +7,11 @@
 // The elements still register, so a template that renders one gets an empty box and a
 // console warning instead of an unknown tag that silently does nothing.
 
-import { warnStubbed } from "./stub-warning";
+import { reportStubbed } from "./stub-report";
 
 class StubbedMapElement extends HTMLElement {
   public connectedCallback(): void {
-    warnStubbed("maps", `showing <${this.localName}>`);
+    reportStubbed("maps", `showing <${this.localName}>`);
   }
 }
 

--- a/src/stubs/ha-map.ts
+++ b/src/stubs/ha-map.ts
@@ -1,0 +1,28 @@
+// Stub for HA's <ha-map> and <ha-locations-editor> — see build-scripts/stubs.cjs.
+//
+// These two components are the only modules in the tree that reach leaflet, leaflet-draw,
+// leaflet.markercluster and maplibre-gl; nothing else imports them for anything but types.
+// The KNX panel has no map to draw, so replacing the pair drops all four libraries.
+//
+// The elements still register, so a template that renders one gets an empty box and a
+// console warning instead of an unknown tag that silently does nothing.
+
+import { warnStubbed } from "./stub-warning";
+
+class StubbedMapElement extends HTMLElement {
+  public connectedCallback(): void {
+    warnStubbed("maps", `showing <${this.localName}>`);
+  }
+}
+
+// The panel runs in its own iframe, so this registry is ours alone — but the guard costs
+// nothing and keeps a second definition from throwing if that ever stops being true.
+for (const tagName of ["ha-map", "ha-locations-editor"]) {
+  if (!customElements.get(tagName)) {
+    customElements.define(tagName, class extends StubbedMapElement {});
+  }
+}
+
+// hui-map-card-editor builds a selector out of these. Every other import of the two
+// modules is either a side-effect import or `import type`.
+export const MAP_CARD_MARKER_LABEL_MODES = ["name", "state", "attribute", "icon"];

--- a/src/stubs/hls.ts
+++ b/src/stubs/hls.ts
@@ -4,9 +4,9 @@
 // support, then to a "video not supported" message. Reporting false walks it down that
 // path instead of leaving it with a broken player object.
 
-import { warnStubbed } from "./stub-warning";
+import { reportStubbed } from "./stub-report";
 
-warnStubbed("hls.js", "playing camera streams that the browser cannot play natively");
+reportStubbed("hls.js", "playing camera streams that the browser cannot play natively");
 
 export default {
   isSupported: (): boolean => false,

--- a/src/stubs/hls.ts
+++ b/src/stubs/hls.ts
@@ -1,0 +1,13 @@
+// Stub for hls.js — see build-scripts/stubs.cjs.
+//
+// ha-hls-player asks `Hls.isSupported()` first and falls back to the browser's own HLS
+// support, then to a "video not supported" message. Reporting false walks it down that
+// path instead of leaving it with a broken player object.
+
+import { warnStubbed } from "./stub-warning";
+
+warnStubbed("hls.js", "playing camera streams that the browser cannot play natively");
+
+export default {
+  isSupported: (): boolean => false,
+};

--- a/src/stubs/media-player.ts
+++ b/src/stubs/media-player.ts
@@ -1,0 +1,29 @@
+// Stub for HA's media browser — see build-scripts/stubs.cjs.
+//
+// KNX has no media_player entities, so nothing in the panel can open a media browser. The
+// `show-*-dialog` helpers are deliberately left alone: they are what other components
+// import by name, and what they open is this.
+
+import { warnStubbed } from "./stub-warning";
+
+class StubbedMediaElement extends HTMLElement {
+  public connectedCallback(): void {
+    warnStubbed("media browser", `showing <${this.localName}>`);
+  }
+}
+
+for (const tagName of [
+  "dialog-join-media-players",
+  "dialog-media-manage",
+  "dialog-media-player-browse",
+  "ha-browse-media-manual",
+  "ha-browse-media-tts",
+  "ha-media-browser-thumbnail",
+  "ha-media-manage-button",
+  "ha-media-player-browse",
+  "ha-media-upload-button",
+]) {
+  if (!customElements.get(tagName)) {
+    customElements.define(tagName, class extends StubbedMediaElement {});
+  }
+}

--- a/src/stubs/media-player.ts
+++ b/src/stubs/media-player.ts
@@ -4,11 +4,11 @@
 // `show-*-dialog` helpers are deliberately left alone: they are what other components
 // import by name, and what they open is this.
 
-import { warnStubbed } from "./stub-warning";
+import { reportStubbed } from "./stub-report";
 
 class StubbedMediaElement extends HTMLElement {
   public connectedCallback(): void {
-    warnStubbed("media browser", `showing <${this.localName}>`);
+    reportStubbed("media browser", `showing <${this.localName}>`);
   }
 }
 

--- a/src/stubs/qr-scanner.ts
+++ b/src/stubs/qr-scanner.ts
@@ -3,9 +3,9 @@
 // ha-qr-scanner bails out with "no camera found" when `hasCamera()` is false, which is the
 // closest thing to the truth: this build has no scanner to point a camera at.
 
-import { warnStubbed } from "./stub-warning";
+import { reportStubbed } from "./stub-report";
 
-warnStubbed("qr-scanner", "scanning QR codes with the camera");
+reportStubbed("qr-scanner", "scanning QR codes with the camera");
 
 export default {
   hasCamera: (): Promise<boolean> => Promise.resolve(false),

--- a/src/stubs/qr-scanner.ts
+++ b/src/stubs/qr-scanner.ts
@@ -1,0 +1,12 @@
+// Stub for qr-scanner — see build-scripts/stubs.cjs.
+//
+// ha-qr-scanner bails out with "no camera found" when `hasCamera()` is false, which is the
+// closest thing to the truth: this build has no scanner to point a camera at.
+
+import { warnStubbed } from "./stub-warning";
+
+warnStubbed("qr-scanner", "scanning QR codes with the camera");
+
+export default {
+  hasCamera: (): Promise<boolean> => Promise.resolve(false),
+};

--- a/src/stubs/stub-report.ts
+++ b/src/stubs/stub-report.ts
@@ -4,12 +4,16 @@
 /**
  * Report that a stubbed-out module was actually reached.
  *
+ * This is an error, not a warning: reaching one of these means the panel is missing a
+ * feature it just tried to use, and the console filter that hides warnings is exactly
+ * where that would go unnoticed.
+ *
  * `name` must match the `name` of the entry in build-scripts/stubs.cjs, so that whoever
  * reads this in a console can find the one place that put the stub there.
  */
-export const warnStubbed = (name: string, detail: string): void => {
+export const reportStubbed = (name: string, detail: string): void => {
   // eslint-disable-next-line no-console
-  console.warn(
+  console.error(
     `[KNX] "${name}" is stubbed out in this build, so ${detail} does not work here. ` +
       "The KNX panel is not supposed to need it — if it does, remove the entry from " +
       "build-scripts/stubs.cjs.",

--- a/src/stubs/stub-warning.ts
+++ b/src/stubs/stub-warning.ts
@@ -1,0 +1,17 @@
+// Shared by everything in this directory. See build-scripts/stubs.cjs for the list of
+// modules that get replaced and why.
+
+/**
+ * Report that a stubbed-out module was actually reached.
+ *
+ * `name` must match the `name` of the entry in build-scripts/stubs.cjs, so that whoever
+ * reads this in a console can find the one place that put the stub there.
+ */
+export const warnStubbed = (name: string, detail: string): void => {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[KNX] "${name}" is stubbed out in this build, so ${detail} does not work here. ` +
+      "The KNX panel is not supposed to need it — if it does, remove the entry from " +
+      "build-scripts/stubs.cjs.",
+  );
+};

--- a/src/util/empty.js
+++ b/src/util/empty.js
@@ -1,3 +1,0 @@
-/* empty file that we alias some files to that we don't want to include */
-
-export {}; // for Babel to treat as a module


### PR DESCRIPTION
The panel is built from the whole homeassistant-frontend source tree, so it inherits every dependency HA has whether or not the panel can reach one. The unreachable ones still ship: rspack emits them as lazy chunks nobody fetches, but `knx_frontend/` is zipped into the wheel as-is, so every Home Assistant install pays for them on disk.

This replaces the modules that pull the biggest of those in with stubs, and gives that mechanism somewhere to live.

**70.04 MB -> 54.88 MB installed (-21.6%), 32.77 MB -> 25.97 MB download (-20.8%)**, measured with `yarn build:size` after a full build at each commit:

| commit | installed | download | Δ installed |
| --- | ---: | ---: | ---: |
| base (`b3cf98d`) | 70.04 MB | 32.77 MB | — |
| Collect build-time stubs in one registry | 70.05 MB | 32.78 MB | +0.01 MB |
| Stub out the map components | 62.86 MB | 29.77 MB | **-7.19 MB** |
| Stub out the echarts chart engine | 59.02 MB | 27.97 MB | **-3.84 MB** |
| Stub out the calendar components | 56.07 MB | 26.60 MB | **-2.95 MB** |
| Stub out the media browser | 55.22 MB | 26.13 MB | -0.85 MB |
| Stub out cropperjs | 54.89 MB | 25.97 MB | -0.33 MB |
| Report reaching a stub as an error | 54.88 MB | 25.97 MB | -0.01 MB |

**This changes nothing about what a KNX user downloads.** The entrypoint is 576.0 KiB before and 575.9 KiB after — every byte removed was in a lazy chunk the panel never requests. It is a wheel and disk-footprint change, the number `build:size` reports on every PR.

## What is stubbed, and why those

| entry | takes out |
| --- | --- |
| `maps` | leaflet, leaflet-draw, leaflet.markercluster, maplibre-gl |
| `echarts` | echarts, zrender, the chart2music extension |
| `calendars` | @fullcalendar, luxon, rrule |
| `media browser` | the browse dialogs and the components behind them |
| `cropperjs` | cropperjs |
| `hls.js`, `qr-scanner` | unchanged — these were already being stubbed |

Each was picked by cutting a candidate out of a real module graph (an rspack compile with `reasons`) and measuring what becomes unreachable, then verifying against the built output that the library is gone rather than merely moved. In each case the cut point is a narrow one: `<ha-map>` and `<ha-locations-editor>` are the only modules in the tree that reach any of the four map libraries, `resources/echarts` is the only door the chart engine comes in through, `<ha-full-calendar>` and `<ha-schedule-form>` the only ones reaching @fullcalendar.

Considered and rejected: `panels/lovelace` (1.9 MB) and `panels/config` (1.1 MB) are genuinely entangled — the obvious door, `ha-selector` lazily loading `ha-selector-ui-action`, turns out to be one of many, and cutting it removes zero modules. sortablejs (117 KB) is plausible but wants someone to confirm no KNX view reorders lists. @vvo/tzdb, culori, codemirror and js-yaml are all really used.

## The part worth reviewing

`build-scripts/stubs.cjs` is the list, one entry per library, each carrying the reason it is there, and it is the answer to "what broke and why": every stub logs

```
[KNX] "<entry name>" is stubbed out in this build, so <what> does not work here.
```

as a console **error** the moment it is actually reached. Deleting the entry is all it takes to get the real module back. The rules for adding one are in `build-scripts/README.md`, which replaces the old "Camera stubs" section.

A stub is a real module rather than an empty file, which is what lifts the old restriction that anything behind a static `import X from "pkg"` could not be stubbed — that is how cropperjs, previously documented as a known exception, could finally go. Where it was cheap the stub makes the consumer degrade instead of throw: `Hls.isSupported()` returning false walks ha-hls-player down to native playback and then its own "video not supported" message, `QrScanner.hasCamera()` returning false makes ha-qr-scanner report "no camera found". Both previously handed the consumer an empty module and a TypeError. The element stubs register the tag and report from `connectedCallback`, so a template that renders one gets an empty box and a precise error rather than an unknown tag and silence.

The risk this carries is the obvious one: if some KNX view really does reach one of these, it now renders nothing. That is what the error message is for.

## Checks

`yarn lint:eslint`, `yarn lint:prettier` and `yarn lint:lit` pass.

`yarn lint:types` (63 errors) and `yarn test` (6 failures in the group-monitor cache and view specs) fail identically on `b3cf98d` with none of these changes applied, so they came in with the upstream bump and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)