### PR TITLE
Fix the type errors under lint:types, and run tsc in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,21 @@ jobs:
       - name: Check for duplicate dependencies
         run: yarn dedupe --check
 
+  types:
+    name: Types
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out files from GitHub
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Setup Node and Dependencies
+        uses: ./.github/actions/setup
+
+      - name: Run tsc
+        run: yarn run lint:types
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Setup Node and Dependencies
         uses: ./.github/actions/setup
 
+      # tsc resolves imports of build/mdi/iconList.json and build/translations/
+      # translationMetadata.json, which do not exist until these have run. Every other job
+      # that needs them gets them from `yarn build`; this one has no reason to build.
+      - name: Generate build inputs
+        run: yarn gulp gen-icons-json build-translations
+
       - name: Run tsc
         run: yarn run lint:types
 

--- a/src/components/data-table/knx-data-table-related-label.ts
+++ b/src/components/data-table/knx-data-table-related-label.ts
@@ -78,7 +78,7 @@ class KnxDataTableRelatedLabel extends LitElement {
         : this._renderEntityYamlItem(this.entitiesYaml[0]);
     }
 
-    const openDropdownLabel = this.localize("ui.components.target-picker.selected.entity", {
+    const openDropdownLabel = this.localize("ui.components.target-picker.entities_count", {
       count: itemCount,
     });
 

--- a/src/components/knx-configure-entity.ts
+++ b/src/components/knx-configure-entity.ts
@@ -16,9 +16,14 @@ import type { HomeAssistant, ValueChangedEvent } from "@ha/types";
 import "./knx-form";
 import { renderConfigureEntityCard } from "./knx-configure-entity-options";
 import { KNXLogger } from "../tools/knx-logger";
-import { setNestedValue } from "../utils/config-helper";
+import { configPathFromEvent, setNestedValue } from "../utils/config-helper";
 import { extractValidationErrors } from "../utils/validation";
-import type { EntityData, ErrorDescription, SupportedPlatform } from "../types/entity_data";
+import type {
+  BaseEntityData,
+  EntityData,
+  ErrorDescription,
+  SupportedPlatform,
+} from "../types/entity_data";
 import type { KNX } from "../types/knx";
 import { getPlatformStyle } from "../utils/common";
 import type { PlatformStyle } from "../utils/common";
@@ -55,7 +60,10 @@ export class KNXConfigureEntity extends LitElement {
     this.platformStyle = getPlatformStyle(this.platform);
     if (!this.config) {
       // set base keys to get better validation error messages
-      this.config = { entity: {}, knx: {} };
+      // `entity` starts out empty on purpose: the backend then reports one error per
+      // missing field instead of one complaint about the whole object, and the form fills
+      // them in from there.
+      this.config = { entity: {} as BaseEntityData, knx: {} };
 
       // url params are extracted to config.
       // /knx/entities/create/binary_sensor?knx.ga_sensor.state=0/1/4
@@ -111,7 +119,7 @@ export class KNXConfigureEntity extends LitElement {
 
   private _updateConfig(ev: ValueChangedEvent<any>): void {
     ev.stopPropagation();
-    const key = ev.target.key;
+    const key = configPathFromEvent(ev);
     const value = ev.detail.value;
     setNestedValue(this.config!, key, value, logger);
     fireEvent(this, "knx-entity-configuration-changed", this.config);

--- a/src/components/knx-dpt-dialog-selector.ts
+++ b/src/components/knx-dpt-dialog-selector.ts
@@ -66,7 +66,7 @@ class KnxDptDialogSelector extends LitElement {
                         `component.knx.config_panel.dpt.options.${this.value.replace(".", "_")}`,
                       ) ||
                       (this.knx.dptMetadata[this.value]?.name
-                        ? snakeToTitleCase(this.knx.dptMetadata[this.value].name)
+                        ? snakeToTitleCase(this.knx.dptMetadata[this.value].name ?? "")
                         : this.localize("state.default.unknown"))
                     }
                   </div>

--- a/src/components/knx-expose-template-preview.ts
+++ b/src/components/knx-expose-template-preview.ts
@@ -67,7 +67,7 @@ export class KnxExposeTemplatePreview extends LitElement {
     this._unsubscribeTemplate();
   }
 
-  protected willUpdate(changedProperties: PropertyValues<this>) {
+  protected willUpdate(changedProperties: PropertyValues) {
     if (changedProperties.has("valueTemplate")) {
       this._scheduleTemplateUpdateTyping();
     } else if (
@@ -141,7 +141,7 @@ export class KnxExposeTemplatePreview extends LitElement {
       this._error =
         err instanceof Error
           ? err.message
-          : this.localize("ui.panel.config.developer-tools.tabs.templates.unknown_error_template");
+          : this.localize("ui.panel.config.tools.tabs.templates.unknown_error_template");
     }
   }
 

--- a/src/components/knx-form.ts
+++ b/src/components/knx-form.ts
@@ -29,7 +29,7 @@ import type {
   GroupSelect,
   GASelector,
 } from "../types/schema";
-import { getNestedValue, setNestedValue } from "../utils/config-helper";
+import { configPathFromEvent, getNestedValue, setNestedValue } from "../utils/config-helper";
 
 const logger = new KNXLogger("knx-form");
 
@@ -396,7 +396,7 @@ export class KnxForm extends LitElement {
 
   private _updateGroupSelectOption(ev: ValueChangedEvent<any>) {
     ev.stopPropagation();
-    const key = ev.target.key;
+    const key = configPathFromEvent(ev);
     const selectedIndex = parseInt(ev.detail.value, 10);
     const previousIndex = this._selectedGroupSelectOptions[key];
 
@@ -432,7 +432,7 @@ export class KnxForm extends LitElement {
 
   private _updateConfig(ev: ValueChangedEvent<any>) {
     ev.stopPropagation();
-    const key = ev.target.key;
+    const key = configPathFromEvent(ev);
     const value = ev.detail.value;
     setNestedValue(this.config!, key, value, logger);
     fireEvent(this, "knx-form-config-changed", { value: this.config });

--- a/src/components/knx-group-address-selector.ts
+++ b/src/components/knx-group-address-selector.ts
@@ -134,7 +134,7 @@ export class GroupAddressSelector extends LitElement {
     this._getDPTsFromClasses(dptClasses).map(dptToString),
   );
 
-  protected willUpdate(changedProps: PropertyValues<this>) {
+  protected willUpdate(changedProps: PropertyValues) {
     this._selectedDPTValue = this.config.dpt ?? this._selectedDPTValue;
     const selectedDPT = this.getDptByValue(this._selectedDPTValue);
 

--- a/src/components/knx-project-device-tree.ts
+++ b/src/components/knx-project-device-tree.ts
@@ -238,7 +238,7 @@ export class KNXProjectDeviceTree extends LitElement {
   }
 
   private _selectDevice(ev: CustomEvent) {
-    const device = ev.target.device;
+    const device = (ev.target as HTMLElement & { device: DeviceTreeItem }).device;
     logger.debug("select device", device);
     this._selectedDevice = device;
     this.scrollTop = 0;

--- a/src/components/knx-selector-row.ts
+++ b/src/components/knx-selector-row.ts
@@ -68,12 +68,11 @@ export class KnxSelectorRow extends LitElement {
       }
 
       // selector specific helper text
+      const numberSelector =
+        "number" in this.selector.selector ? this.selector.selector.number : undefined;
       this._selectorHelper =
-        isNumber && this.selector.selector.number?.mode === "box"
-          ? numberRangeHelper(
-              this.selector.selector.number?.min,
-              this.selector.selector.number?.max,
-            )
+        numberSelector?.mode === "box"
+          ? numberRangeHelper(numberSelector.min, numberSelector.max)
           : undefined;
     }
   }

--- a/src/components/knx-sync-state-selector-row.ts
+++ b/src/components/knx-sync-state-selector-row.ts
@@ -7,6 +7,8 @@ import "@ha/components/ha-selector/ha-selector-number";
 import "@ha/components/ha-selector/ha-selector-select";
 import type { HomeAssistant } from "@ha/types";
 
+import { configPathFromEvent } from "../utils/config-helper";
+
 @customElement("knx-sync-state-selector-row")
 export class KnxSyncStateSelectorRow extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -102,7 +104,7 @@ export class KnxSyncStateSelectorRow extends LitElement {
     ev.stopPropagation();
     let strategy: string;
     let minutes: number;
-    if (ev.target.key === "strategy") {
+    if (configPathFromEvent(ev) === "strategy") {
       strategy = ev.detail.value;
       minutes = this._minutes;
     } else {

--- a/src/knx-router.ts
+++ b/src/knx-router.ts
@@ -15,7 +15,7 @@ import type { PageNavigation } from "@ha/layouts/hass-tabs-subpage";
 import { mainWindow } from "@ha/common/dom/get_main_window";
 import type { KNX } from "./types/knx";
 import { KNXLogger } from "./tools/knx-logger";
-import type { KnxPageNavigation } from "./types/navigation";
+import type { KnxPageNavigation, KnxTranslationKey } from "./types/navigation";
 
 const logger = new KNXLogger("router");
 
@@ -28,7 +28,7 @@ export const BASE_URL = "/knx";
  * description keys in sync.
  */
 function _knxPageNavigationFactory(
-  pageNavigation: PageNavigation & { baseTranslationKey: string },
+  pageNavigation: PageNavigation & { baseTranslationKey: KnxTranslationKey },
 ): KnxPageNavigation {
   return {
     ...pageNavigation,

--- a/src/localize/localize.ts
+++ b/src/localize/localize.ts
@@ -1,4 +1,5 @@
 import { IntlMessageFormat } from "intl-messageformat";
+import type { LocalizeKeys } from "@ha/common/translations/localize";
 import type { HomeAssistant } from "@ha/types";
 import * as de from "./languages/de.json";
 import * as en from "./languages/en.json";
@@ -33,7 +34,7 @@ export function localize(hass: HomeAssistant, key: string, replace?: Record<stri
   const translatedValue = languages[lang]?.[key] || languages[DEFAULT_LANGUAGE][key];
 
   if (!translatedValue) {
-    const hassTranslation = hass.localize(key, replace);
+    const hassTranslation = hass.localize(key as LocalizeKeys, replace);
     if (hassTranslation) {
       return hassTranslation;
     }

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -9,7 +9,10 @@ export interface LocationChangedEvent {
   detail?: { route: Route; force?: boolean };
 }
 
+/** A key under KNX's own translations, which is what `hass.localize` accepts. */
+export type KnxTranslationKey = `component.${string}`;
+
 export interface KnxPageNavigation extends PageNavigation {
-  descriptionTranslationKey: string;
-  translationKey: string;
+  descriptionTranslationKey: KnxTranslationKey;
+  translationKey: KnxTranslationKey;
 }

--- a/src/utils/config-helper.ts
+++ b/src/utils/config-helper.ts
@@ -44,8 +44,8 @@ export const configPathFromEvent = (ev: Event): string => {
  * @param config - The configuration object to modify
  * @param path - Dot-separated path to the property (e.g., "knx.color.ga_color")
  * @param value - The value to set. If undefined, the property will be removed
- * @param callerLogger - Optional logger instance for debugging operations, so that the
- *   messages carry the name of the module doing the writing
+ * @param callerLogger - Logger to attribute the debug lines to, so they carry the name of
+ *   the module doing the writing. Falls back to this module's own
  *
  * @example
  * ```typescript
@@ -66,9 +66,14 @@ export function setNestedValue(
   value: any,
   callerLogger?: KNXLogger,
 ) {
+  const log = callerLogger ?? logger;
   const keys = path.split(".");
   const targetKey = keys.pop();
-  if (!targetKey) return;
+  if (!targetKey) {
+    // configPathFromEvent has already said why, when it is the one handing us "".
+    log.debug(`nothing to write: no key in path "${path}"`);
+    return;
+  }
   let current = config;
   for (const key of keys) {
     if (!(key in current)) {
@@ -78,14 +83,14 @@ export function setNestedValue(
     current = current[key];
   }
   if (value === undefined) {
-    if (callerLogger) callerLogger.debug(`remove ${targetKey} at ${path}`);
+    log.debug(`remove ${targetKey} at ${path}`);
     delete current[targetKey];
     if (!Object.keys(current).length && keys.length > 0) {
       // when no other keys in this, recursively remove empty objects
-      setNestedValue(config, keys.join("."), undefined);
+      setNestedValue(config, keys.join("."), undefined, callerLogger);
     }
   } else {
-    if (callerLogger) callerLogger.debug(`update ${targetKey} at ${path} with value`, value);
+    log.debug(`update ${targetKey} at ${path} with value`, value);
     current[targetKey] = value;
   }
 }

--- a/src/utils/config-helper.ts
+++ b/src/utils/config-helper.ts
@@ -1,6 +1,16 @@
 import type { KNXLogger } from "../tools/knx-logger";
 
 /**
+ * Reads the config path back off the element that fired a change event.
+ *
+ * Every form row renders its input with a `key` property holding the dot-separated path it
+ * edits, so that one handler can serve all of them. The DOM knows nothing about that, and
+ * types `ev.target` as `EventTarget | null` besides.
+ */
+export const configPathFromEvent = (ev: Event): string =>
+  (ev.target as HTMLElement & { key: string }).key;
+
+/**
  * Sets a nested value in a configuration object using a dot-separated path.
  * Creates intermediate objects as needed when setting values.
  * When value is undefined, removes the property and cleans up empty parent objects.

--- a/src/utils/config-helper.ts
+++ b/src/utils/config-helper.ts
@@ -1,4 +1,14 @@
-import type { KNXLogger } from "../tools/knx-logger";
+import { KNXLogger } from "../tools/knx-logger";
+
+const logger = new KNXLogger("config-helper");
+
+/** `ha-selector < knx-selector-row < knx-form`, as far up as the event was composed. */
+const composedElementPath = (ev: Event): string =>
+  ev
+    .composedPath()
+    .map((node) => (node as HTMLElement).localName)
+    .filter(Boolean)
+    .join(" < ");
 
 /**
  * Reads the config path back off the element that fired a change event.
@@ -6,9 +16,25 @@ import type { KNXLogger } from "../tools/knx-logger";
  * Every form row renders its input with a `key` property holding the dot-separated path it
  * edits, so that one handler can serve all of them. The DOM knows nothing about that, and
  * types `ev.target` as `EventTarget | null` besides.
+ *
+ * A row that forgot its `key` is a bug in the caller, and a quiet one: `setNestedValue`
+ * would fail somewhere down in `path.split`, and a handler comparing the path against a
+ * literal would just take its other branch. So say so — with the chain of elements the
+ * event came through, which locates the offending row better than the name of whichever
+ * module happened to handle it — and return the empty path that `setNestedValue` ignores.
  */
-export const configPathFromEvent = (ev: Event): string =>
-  (ev.target as HTMLElement & { key: string }).key;
+export const configPathFromEvent = (ev: Event): string => {
+  const target = ev.target as (HTMLElement & { key?: string }) | null;
+  if (target?.key === undefined) {
+    logger.warn(
+      `${ev.type} from an element with no "key" to write to, so its value is dropped:`,
+      composedElementPath(ev),
+      target,
+    );
+    return "";
+  }
+  return target.key;
+};
 
 /**
  * Sets a nested value in a configuration object using a dot-separated path.
@@ -18,7 +44,8 @@ export const configPathFromEvent = (ev: Event): string =>
  * @param config - The configuration object to modify
  * @param path - Dot-separated path to the property (e.g., "knx.color.ga_color")
  * @param value - The value to set. If undefined, the property will be removed
- * @param logger - Optional logger instance for debugging operations
+ * @param callerLogger - Optional logger instance for debugging operations, so that the
+ *   messages carry the name of the module doing the writing
  *
  * @example
  * ```typescript
@@ -37,7 +64,7 @@ export function setNestedValue(
   config: Record<string, any>,
   path: string,
   value: any,
-  logger?: KNXLogger,
+  callerLogger?: KNXLogger,
 ) {
   const keys = path.split(".");
   const targetKey = keys.pop();
@@ -51,14 +78,14 @@ export function setNestedValue(
     current = current[key];
   }
   if (value === undefined) {
-    if (logger) logger.debug(`remove ${targetKey} at ${path}`);
+    if (callerLogger) callerLogger.debug(`remove ${targetKey} at ${path}`);
     delete current[targetKey];
     if (!Object.keys(current).length && keys.length > 0) {
       // when no other keys in this, recursively remove empty objects
       setNestedValue(config, keys.join("."), undefined);
     }
   } else {
-    if (logger) logger.debug(`update ${targetKey} at ${path} with value`, value);
+    if (callerLogger) callerLogger.debug(`update ${targetKey} at ${path} with value`, value);
     current[targetKey] = value;
   }
 }

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -1,5 +1,5 @@
 import type { HomeAssistant } from "@ha/types";
-import type { DeviceRegistryEntry } from "@ha/data/device_registry";
+import type { DeviceRegistryEntry } from "@ha/data/device/device_registry";
 
 const isKnxIdentifier = (identifier: [string, string]): boolean => identifier[0] === "knx";
 

--- a/src/utils/drag-drop-context.ts
+++ b/src/utils/drag-drop-context.ts
@@ -4,6 +4,9 @@ import { KNXLogger } from "../tools/knx-logger";
 
 const logger = new KNXLogger("knx-drag-drop-context");
 
+/** The project tree tags each draggable row with the group address it stands for. */
+type GroupAddressElement = HTMLElement & { ga?: GroupAddress };
+
 const contextKey = Symbol("drag-drop-context");
 
 export class DragDropContext {
@@ -23,8 +26,8 @@ export class DragDropContext {
 
   // arrow function => so `this` refers to the class instance, not the event source
   public gaDragStartHandler = (ev: DragEvent) => {
-    const target = ev.target as HTMLElement;
-    const ga = target.ga as GroupAddress;
+    const target = ev.target as GroupAddressElement;
+    const ga = target.ga;
     if (!ga) {
       logger.warn("dragstart: no 'ga' property found", target);
       return;
@@ -42,8 +45,8 @@ export class DragDropContext {
   };
 
   public gaDragIndicatorStartHandler = (ev: MouseEvent) => {
-    const target = ev.target as HTMLElement;
-    const ga = target.ga as GroupAddress;
+    const target = ev.target as GroupAddressElement;
+    const ga = target.ga;
     if (!ga) {
       return;
     }

--- a/src/views/dashboard.ts
+++ b/src/views/dashboard.ts
@@ -27,12 +27,22 @@ import type { UnsubscribeFunc } from "home-assistant-js-websocket";
 import { showKnxProjectUploadDialog } from "../dialogs/show-knx-project-upload-dialog";
 import { showKnxTimeServerDialog } from "../dialogs/show-knx-time-server-dialog";
 import { showKnxSendDialog } from "../dialogs/show-knx-send-dialog";
-import type { KnxPageNavigation } from "../types/navigation";
+import type { KnxPageNavigation, KnxTranslationKey } from "../types/navigation";
 import type { KNX } from "../types/knx";
 import { knxMainTabs } from "../knx-router";
 import { KNXLogger } from "../tools/knx-logger";
 
 const logger = new KNXLogger("knx-dashboard");
+
+/** One of the action buttons below the navigation list. */
+interface DashboardButton {
+  /** Root key; `.title` and `.description` below it name the button. */
+  translationKey: KnxTranslationKey;
+  click: () => void;
+  iconPath: string;
+  iconColor: string;
+  validConfigEntryStates: Set<string>;
+}
 
 @customElement("knx-dashboard")
 export class KnxDashboard extends SubscribeMixin(LitElement) {
@@ -77,7 +87,7 @@ export class KnxDashboard extends SubscribeMixin(LitElement) {
     }));
   }
 
-  private _buttonItems = [
+  private _buttonItems: DashboardButton[] = [
     {
       translationKey: "component.knx.config_panel.dashboard.send",
       click: this._openSendDialog,
@@ -138,7 +148,6 @@ export class KnxDashboard extends SubscribeMixin(LitElement) {
     await this.hass.loadBackendTranslation("config", "knx");
     showConfigFlowDialog(this, {
       startFlowHandler: this.knx.config_entry.domain,
-      showAdvanced: this.hass.userData?.showAdvanced,
       manifest: await fetchIntegrationManifest(this.hass, this.knx.config_entry.domain),
       entryId: this.knx.config_entry.entry_id,
       dialogClosedCallback: (params) => {
@@ -165,7 +174,7 @@ export class KnxDashboard extends SubscribeMixin(LitElement) {
             <ha-md-list has-secondary>
               ${map(
                 this._buttonItems,
-                (item) =>
+                (item: DashboardButton) =>
                   html` <ha-md-list-item
                     type="button"
                     @click=${item.click}

--- a/src/views/entities_create.ts
+++ b/src/views/entities_create.ts
@@ -143,7 +143,8 @@ export class KNXCreateEntity extends DirtyStateProviderMixin<EntityData>()(
   protected willUpdate(changedProperties: PropertyValues<this>) {
     super.willUpdate(changedProperties); // dirty state listeners are handled by the mixin
     if (changedProperties.has("route")) {
-      const intent = this.route.prefix.split("/").at(-1);
+      const pathSegments = this.route.prefix.split("/");
+      const intent = pathSegments[pathSegments.length - 1];
       if (intent === "create" || intent === "edit") {
         this._intent = intent;
       } else {
@@ -233,14 +234,11 @@ export class KNXCreateEntity extends DirtyStateProviderMixin<EntityData>()(
         <hass-loading-screen .message=${"Loading entity platform schema."}></hass-loading-screen>
       `,
       error: (err) => this._renderError("Error loading schema", err),
-      complete: () => this._renderEntityConfig(this.entityPlatform),
+      complete: () => this._renderEntityConfig(this.entityPlatform!),
     });
   }
 
-  private _renderError(
-    errorContent: TemplateResult | string,
-    error?: Error | string,
-  ): TemplateResult {
+  private _renderError(errorContent: TemplateResult | string, error?: unknown): TemplateResult {
     logger.error("Error in create/edit entity", error);
     return html`
       <hass-subpage
@@ -558,7 +556,10 @@ export class KNXCreateEntity extends DirtyStateProviderMixin<EntityData>()(
       });
   }
 
-  private _handleValidationError(result: CreateEntityResult, final: boolean): boolean {
+  private _handleValidationError(
+    result: CreateEntityResult,
+    final: boolean,
+  ): result is Extract<CreateEntityResult, { success: false }> {
     // return true if validation error; scroll to alert if final
     if (result.success === false) {
       logger.warn("Validation error", result);

--- a/src/views/expose_view.ts
+++ b/src/views/expose_view.ts
@@ -57,9 +57,21 @@ import { KNXLogger } from "../tools/knx-logger";
 
 const logger = new KNXLogger("knx-expose-view");
 
-export interface EntityRow {
-  entityState?: HassEntity;
+/**
+ * An exposed entity we cannot look up: an expose outlives the entity it was created for,
+ * so the entity may have been deleted since, leaving nothing but the id it was exposed
+ * under. Extending Partial<EntityRegistryEntry> rather than declaring entity_id alone is
+ * what lets the union below be read without narrowing at every property.
+ */
+interface UnknownEntity extends Partial<EntityRegistryEntry> {
   entity_id: string;
+}
+
+/** An exposed entity: its registry entry when we have one, the bare id when we do not. */
+type ExposedEntity = EntityRegistryEntry | UnknownEntity;
+
+export type EntityRow = ExposedEntity & {
+  entityState?: HassEntity;
   friendly_name: string;
   device_name: string;
   area_name: string;
@@ -67,11 +79,7 @@ export interface EntityRow {
   domain: string;
   group_addresses: string[];
   group_address_names: (string | undefined)[];
-}
-
-interface UnknownEntity {
-  entity_id: string;
-}
+};
 
 interface AreaFilterItem {
   id: string;
@@ -114,14 +122,13 @@ export class KNXExposeView extends LitElement {
       return Object.keys(this._exposeGroupsCtx.groups).map(
         (entityId) =>
           entities.find((e) => e.entity_id === entityId) ??
-          ({
-            entity_id: entityId,
-          } as UnknownEntity),
+          // exposed, but no longer in the registry
+          ({ entity_id: entityId } as UnknownEntity),
       );
     },
     watch: ["_exposeGroupsCtx"],
   })
-  private _exposes: (EntityRegistryEntry | UnknownEntity)[] = [];
+  private _exposes: ExposedEntity[] = [];
 
   @state() private _filters: DataTableFiltersValues = {};
 
@@ -144,10 +151,7 @@ export class KNXExposeView extends LitElement {
   };
 
   private _computeRows = memoize(
-    (
-      entries: (EntityRegistryEntry | UnknownEntity)[],
-      projectData: KNXProject | null,
-    ): EntityRow[] =>
+    (entries: ExposedEntity[], projectData: KNXProject | null): EntityRow[] =>
       entries.map((entry) => {
         const entityState: HassEntity | undefined = this.hass.states[entry.entity_id]; // undefined for disabled entities
         const device = entry.device_id ? this.hass.devices[entry.device_id] : undefined;
@@ -201,51 +205,45 @@ export class KNXExposeView extends LitElement {
     },
   );
 
-  private _getAreaFilterData = memoize(
-    (entities: (EntityRegistryEntry | UnknownEntity)[]): AreaFilterItem[] => {
-      const areas = new Map<string, string>();
-      entities.forEach((entity) => {
-        const areaId =
-          entity.area_id || (entity.device_id && this.hass.devices[entity.device_id]?.area_id);
-        if (areaId) {
-          const area = this.hass.areas[areaId];
-          if (area) {
-            areas.set(areaId, area.name);
-          }
+  private _getAreaFilterData = memoize((entities: ExposedEntity[]): AreaFilterItem[] => {
+    const areas = new Map<string, string>();
+    entities.forEach((entity) => {
+      const areaId =
+        entity.area_id || (entity.device_id && this.hass.devices[entity.device_id]?.area_id);
+      if (areaId) {
+        const area = this.hass.areas[areaId];
+        if (area) {
+          areas.set(areaId, area.name);
         }
-      });
-      return Array.from(areas, ([id, name]) => ({ id, name }));
-    },
-  );
+      }
+    });
+    return Array.from(areas, ([id, name]) => ({ id, name }));
+  });
 
-  private _getDeviceFilterData = memoize(
-    (entities: (EntityRegistryEntry | UnknownEntity)[]): DeviceFilterItem[] => {
-      const devices = new Map<string, string>();
-      entities.forEach((entity) => {
-        if (entity.device_id) {
-          const device = this.hass.devices[entity.device_id];
-          if (device) {
-            devices.set(entity.device_id, device.name_by_user ?? device.name ?? entity.device_id);
-          }
+  private _getDeviceFilterData = memoize((entities: ExposedEntity[]): DeviceFilterItem[] => {
+    const devices = new Map<string, string>();
+    entities.forEach((entity) => {
+      if (entity.device_id) {
+        const device = this.hass.devices[entity.device_id];
+        if (device) {
+          devices.set(entity.device_id, device.name_by_user ?? device.name ?? entity.device_id);
         }
-      });
-      return Array.from(devices, ([id, name]) => ({ id, name }));
-    },
-  );
+      }
+    });
+    return Array.from(devices, ([id, name]) => ({ id, name }));
+  });
 
-  private _getDomainFilterData = memoize(
-    (entities: (EntityRegistryEntry | UnknownEntity)[]): DomainFilterItem[] => {
-      const domains = new Map<string, string>();
-      entities.forEach((entity) => {
-        const domain = computeDomain(entity.entity_id);
-        if (!domains.has(domain)) {
-          const domainName = this.hass.localize(`component.${domain}.title`) || domain;
-          domains.set(domain, domainName);
-        }
-      });
-      return Array.from(domains, ([id, name]) => ({ id, name }));
-    },
-  );
+  private _getDomainFilterData = memoize((entities: ExposedEntity[]): DomainFilterItem[] => {
+    const domains = new Map<string, string>();
+    entities.forEach((entity) => {
+      const domain = computeDomain(entity.entity_id);
+      if (!domains.has(domain)) {
+        const domainName = this.hass.localize(`component.${domain}.title`) || domain;
+        domains.set(domain, domainName);
+      }
+    });
+    return Array.from(domains, ([id, name]) => ({ id, name }));
+  });
 
   private _getBasicFilterConfig = <
     T extends { id: string; name: string },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,14 @@
 {
+  // Upstream ships a component gallery and an e2e test app that this panel never builds,
+  // and both need generated files we do not generate. Nothing imports them, so dropping
+  // them as root files is enough to keep them out. (Setting "exclude" replaces its
+  // default, which is why node_modules is listed.)
+  "exclude": [
+    "node_modules",
+    ".claude",
+    "homeassistant-frontend/gallery",
+    "homeassistant-frontend/test"
+  ],
   "compilerOptions": {
     "target": "ES2021",
     "lib": ["ES2021", "DOM", "DOM.Iterable", "WebWorker"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,7 +37,6 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       reporter: ["text", "html", "json", "lcov"],
       reportOnFailure: true,
-      all: true,
       provider: "v8",
       reportsDirectory: "test/coverage",
       // Coverage thresholds are currently disabled to allow gradual improvement of test coverage.


### PR DESCRIPTION
`yarn lint:types` had 63 errors on main. CI runs eslint and prettier but not tsc, and the build never catches a type error either — babel and swc strip types without checking them — so they had been accumulating quietly, mostly from upstream API changes arriving with submodule bumps.

## Three were live bugs

- **knx-data-table-related-label** asked for `ui.components.target-picker.selected.entity`, a key upstream deleted. `localize` returns nothing for an unknown key, so that dropdown label has been rendering **empty**. It is `entities_count` now, which is the string upstream replaced it with.
- **knx-expose-template-preview** asked for the template error string under `ui.panel.config.developer-tools`, renamed upstream to `ui.panel.config.tools`. Same silent-empty failure, on the error message shown when a template fails to render.
- **dashboard** passed `showAdvanced: this.hass.userData?.showAdvanced` to `showConfigFlowDialog`. Both sides of that are gone from upstream, so it read `undefined` and passed it to a parameter that no longer exists.

## The rest is saying what the code already meant

- `expose_view` read `device_id`, `area_id`, `name` and `disabled_by` off `EntityRegistryEntry | UnknownEntity`, a union whose second member declared `entity_id` and nothing else — 18 of the 63 errors. `UnknownEntity` stays, because an expose outlives the entity it was created for and the type should say so; it now extends `Partial<EntityRegistryEntry>`, which is what lets the union be read without narrowing at every property. `EntityRow` builds on the union instead of redeclaring a subset of its fields.
- Navigation and dashboard button translation keys are `` `component.${string}` ``, which is what `hass.localize` accepts. Typing them as plain `string` is what made every call an error.
- Form rows tag their input with the config path it edits and read it back off the event target — a cast in every handler, now one documented helper, `configPathFromEvent`, next to the `setNestedValue` it feeds.
- `_handleValidationError` returns a type predicate, so the code after the early return knows creation succeeded and `entity_id` exists.
- `PropertyValues<this>` cannot name a private property, so the two `willUpdate` methods that check private state take the untyped `PropertyValues`, as the rest of the panel does.
- Assorted: the device registry moved under `data/device/`, the number selector needs narrowing out of the `Selector` union, `.at(-1)` is ES2022 while the project compiles against the ES2021 lib, and vitest 4 dropped `coverage.all`.

`tsconfig` now excludes upstream's component gallery and e2e app: neither is part of this panel, both need generated files we do not generate, and nothing imports them.

## Two things worth a look

**The Types job will be red, and that is expected.** One error is left and it belongs to homeassistant-frontend: `hui-view-background-editor` reads `this._config` for a property named `config`, so that editor throws when it renders. Fixed upstream in home-assistant/frontend#53802, which is newer than the pinned submodule, so the next bump clears it. It is a separate job rather than a step in Lint precisely because it is expected to fail — a failing step would end the Lint job and take eslint, prettier and the dedupe check down with it.

**`configPathFromEvent` now reports a row that forgot its `key`.** That failure used to be silent in one place and confusing in the others: `knx-sync-state-selector-row` compares the path against `"strategy"` and would just take its other branch and write the wrong field, while `knx-form` and `knx-configure-entity` handed `undefined` to `setNestedValue` and died in `path.split` with nothing pointing back at the row. It warns through the module's own logger, so no caller can swallow it by forgetting to pass one, and identifies the row by the chain of elements the event was composed through (`ha-selector < knx-selector-row < knx-form`) rather than by whichever module happened to handle it. `setNestedValue` falls back to the same logger for the same reason, and its recursive prune now passes the caller's logger on, so removing a nested value logs the whole cascade instead of only its first step.

## Checks

eslint, prettier, lit-analyzer, `yarn dedupe --check` and the 270 tests all pass; `lint:types` is down to the single upstream error. No behaviour change beyond the three fixes above, and the build output is unchanged in size.

One note for anyone running the suite locally: it needs the Node in `.nvmrc` (24.19.0). On Node 25, jsdom 30.0.1 hands the test environment a `localStorage` without `getItem` or `clear`, and the two group-monitor suites fail on that alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)