### PR TITLE
Fix payload selector for DPT 1, 2 and 3

### DIFF
--- a/src/components/knx-payload-selector.test.ts
+++ b/src/components/knx-payload-selector.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { KnxPayloadSelector } from "./knx-payload-selector";
+import type { DPTMetadata } from "../types/websocket";
+
+const dptMeta = (overrides: Partial<DPTMetadata>): DPTMetadata =>
+  ({
+    dpt_class: "numeric",
+    main: 0,
+    sub: null,
+    name: null,
+    unit: null,
+    sensor_device_class: null,
+    sensor_state_class: null,
+    payload_length: 1,
+    ...overrides,
+  }) as DPTMetadata;
+
+// DPT 1, 2 and 3 are packed into the APDU header - the backend reports their
+// `payload_length` as a bit count, everything else as a byte count.
+const DPT_METADATA: Record<string, DPTMetadata> = {
+  "1.001": dptMeta({
+    dpt_class: "enum",
+    main: 1,
+    sub: 1,
+    payload_length: 1,
+    options: ["off", "on"],
+  }),
+  "2.008": dptMeta({
+    dpt_class: "complex",
+    main: 2,
+    sub: 8,
+    payload_length: 2,
+    schema: [
+      { name: "control", type: "boolean", required: true },
+      { name: "value", type: "enum", required: true, options: ["up", "down"] },
+    ],
+  }),
+  "2.001": dptMeta({
+    dpt_class: "complex",
+    main: 2,
+    sub: 1,
+    payload_length: 2,
+    schema: [
+      { name: "control", type: "boolean", required: true },
+      { name: "value", type: "enum", required: true, options: ["off", "on"] },
+    ],
+  }),
+  "3.007": dptMeta({
+    dpt_class: "complex",
+    main: 3,
+    sub: 7,
+    payload_length: 4,
+    schema: [
+      { name: "control", type: "boolean", required: true },
+      { name: "step_code", type: "integer", required: true, value_min: 0, value_max: 7 },
+    ],
+  }),
+  "5.001": dptMeta({ main: 5, sub: 1, payload_length: 1, min: 0, max: 100 }),
+  "9.001": dptMeta({ main: 9, sub: 1, payload_length: 2, min: -273, max: 670760 }),
+};
+
+describe("KnxPayloadSelector", () => {
+  let element: KnxPayloadSelector;
+
+  beforeEach(() => {
+    element = new KnxPayloadSelector();
+    element.knx = { dptMetadata: DPT_METADATA } as any;
+    element.hass = { localize: (key: string) => key } as any;
+    element.required = true;
+  });
+
+  describe("_rawPayloadMax", () => {
+    it.each([
+      ["1.001", 1n],
+      ["2.008", 3n],
+      ["3.007", 15n],
+    ])("uses 2**bits - 1 for APCI packed DPT %s", (dpt, expected) => {
+      element.dpt = dpt;
+      expect((element as any)._rawPayloadMax()).toBe(expected);
+    });
+
+    it("falls back to the DPTBinary limit when metadata is missing", () => {
+      element.dpt = "2.099";
+      expect((element as any)._rawPayloadMax()).toBe(63n);
+    });
+
+    it.each([
+      [1, 255n],
+      [2, 65535n],
+    ])("uses the byte length for other DPTs (%i byte)", (rawLength, expected) => {
+      element.dpt = rawLength === 1 ? "5.001" : "9.001";
+      element.rawLength = rawLength;
+      expect((element as any)._rawPayloadMax()).toBe(expected);
+    });
+  });
+
+  describe("_clampRawPayload", () => {
+    it("keeps the full 2 bit range of DPT 2.x", () => {
+      element.dpt = "2.008";
+      expect((element as any)._clampRawPayload("0x3")).toBe("0x3");
+    });
+
+    it("clamps above the DPT maximum", () => {
+      element.dpt = "2.008";
+      expect((element as any)._clampRawPayload("0x4")).toBe("0x3");
+    });
+  });
+
+  describe("_typedValueForDpt", () => {
+    it("defaults required complex fields so the control-off state is stored", () => {
+      element.dpt = "2.008";
+      expect((element as any)._typedValueForDpt(DPT_METADATA["2.008"])).toEqual({
+        control: false,
+        value: "up",
+      });
+    });
+
+    it("keeps a configured value that still fits the DPT", () => {
+      element.dpt = "2.008";
+      (element as any)._typedValue = { control: true, value: "down" };
+      expect((element as any)._typedValueForDpt(DPT_METADATA["2.008"])).toEqual({
+        control: true,
+        value: "down",
+      });
+    });
+
+    it("fills in required fields missing from a configured value", () => {
+      element.dpt = "2.008";
+      (element as any)._typedValue = { value: "down" };
+      expect((element as any)._typedValueForDpt(DPT_METADATA["2.008"])).toEqual({
+        control: false,
+        value: "down",
+      });
+    });
+
+    it("resets a value whose enum option doesn't fit the DPT", () => {
+      element.dpt = "2.008";
+      (element as any)._typedValue = { control: true, value: "on" }; // DPT 2.001 value
+      expect((element as any)._typedValueForDpt(DPT_METADATA["2.008"])).toEqual({
+        control: false,
+        value: "up",
+      });
+    });
+
+    it("resets a value whose fields don't exist in the DPT schema", () => {
+      element.dpt = "2.008";
+      (element as any)._typedValue = { control: true, step_code: 3 }; // DPT 3.007 value
+      expect((element as any)._typedValueForDpt(DPT_METADATA["2.008"])).toEqual({
+        control: false,
+        value: "up",
+      });
+    });
+  });
+
+  describe("_applyDptTypedDefaults", () => {
+    it("keeps a loaded complex value instead of resetting it to defaults", () => {
+      element.dpt = "2.008";
+      element.value = { value: { control: true, value: "down" } };
+      (element as any)._typedValue = { control: true, value: "down" };
+      (element as any)._mode = "typed";
+      (element as any)._rawLength = 0; // already clamped, so only the typed value can trigger an emit
+
+      const emitted: any[] = [];
+      element.addEventListener("value-changed", (ev: any) => emitted.push(ev.detail.value));
+      (element as any)._applyDptTypedDefaults();
+
+      expect((element as any)._typedValue).toEqual({ control: true, value: "down" });
+      expect(emitted).toHaveLength(0); // no redundant update
+    });
+
+    it("clamps the reported bit count to a raw payload length of 0", () => {
+      element.dpt = "2.008";
+      (element as any)._rawLength = 2;
+      (element as any)._applyDptTypedDefaults();
+      expect((element as any)._rawLength).toBe(0);
+    });
+  });
+
+  describe("_modeChanged", () => {
+    it("seeds DPT defaults when switching to typed mode without a cached value", () => {
+      element.dpt = "2.008";
+      (element as any)._mode = "raw";
+      (element as any)._rawPayload = "0x2";
+
+      const emitted: any[] = [];
+      element.addEventListener("value-changed", (ev: any) => emitted.push(ev.detail.value));
+      const noop = () => undefined;
+      (element as any)._modeChanged({ detail: { value: "typed" }, stopPropagation: noop });
+
+      expect((element as any)._typedValue).toEqual({ control: false, value: "up" });
+      expect(emitted).toEqual([{ value: { control: false, value: "up" } }]);
+    });
+  });
+});

--- a/src/components/knx-payload-selector.ts
+++ b/src/components/knx-payload-selector.ts
@@ -9,6 +9,7 @@ import "@ha/components/input/ha-input";
 
 import { fireEvent } from "@ha/common/dom/fire_event";
 import { conditionalClamp } from "@ha/common/number/clamp";
+import { deepEqual } from "@ha/common/util/deep-equal";
 import type { HaInput } from "@ha/components/input/ha-input";
 import type { NumberSelector, SelectSelector, StringSelector } from "@ha/data/selector";
 import type { HomeAssistant } from "@ha/types";
@@ -129,11 +130,12 @@ export class KnxPayloadSelector extends LitElement {
     const dpt = this._effectiveDpt();
     const dptMeta = dpt ? this.knx.dptMetadata[dpt] : undefined;
     const typedValue = this._typedValueForDpt(dptMeta);
-    const rawLength = dptMeta?.payload_length ?? this._clampRawLength(this._rawLength);
+    // DPT 1, 2 and 3 report a bit count, but a raw payload for them uses length 0
+    const rawLength = this._clampRawLength(dptMeta?.payload_length ?? this._rawLength);
     const rawPayload = this._clampRawPayload(this._rawPayload);
 
     if (
-      typedValue === this._typedValue &&
+      deepEqual(typedValue, this._typedValue) &&
       rawLength === this._rawLength &&
       rawPayload === this._rawPayload
     ) {
@@ -147,9 +149,9 @@ export class KnxPayloadSelector extends LitElement {
 
   /** Typed value to use for a DPT.
    *
-   * Numeric, enum and string values are kept when they still fit the DPT, while
-   * complex values are reset - their fields are specific to the previous DPT.
-   * Otherwise a default is used, so required fields validate without user input.
+   * Values are kept when they still fit the DPT - complex ones are merged onto
+   * the DPT defaults so missing required fields are filled in. Otherwise a
+   * default is used, so required fields validate without user input.
    */
   private _typedValueForDpt(dptMeta?: DPTMetadata): PayloadConfigValue["value"] {
     if (!dptMeta) {
@@ -167,8 +169,21 @@ export class KnxPayloadSelector extends LitElement {
         return dptMeta.options?.includes(this._typedValue as string)
           ? this._typedValue
           : dptMeta.options?.[0];
-      case "complex":
-        return dptMeta.schema ? this._complexDefaults(dptMeta.schema) : undefined;
+      case "complex": {
+        if (!dptMeta.schema) {
+          return undefined;
+        }
+        const defaults = this._complexDefaults(dptMeta.schema);
+        const current = this._typedValue;
+        // Keep the configured fields when they still fit - a complex value is
+        // specific to its DPT, so it is reset when switching to a DPT with a
+        // different shape (e.g. DPT 2.001 `on`/`off` -> 2.008 `up`/`down`).
+        return current !== null &&
+          typeof current === "object" &&
+          this._complexValueFitsSchema(current, dptMeta.schema)
+          ? { ...defaults, ...current }
+          : defaults;
+      }
       case "string":
         if (typeof this._typedValue === "string") {
           return this._typedValue;
@@ -194,6 +209,34 @@ export class KnxPayloadSelector extends LitElement {
       }
     }
     return value;
+  }
+
+  // Whether every field of a stored complex value is known to `schema` and has a
+  // type the schema accepts - values from a different DPT don't fit.
+  private _complexValueFitsSchema(
+    value: Record<string, unknown>,
+    schema: DPTComplexFieldSchema[],
+  ): boolean {
+    const fields = new Map(schema.map((field) => [field.name, field]));
+    return Object.entries(value).every(([name, fieldValue]) => {
+      const field = fields.get(name);
+      if (!field) {
+        return false;
+      }
+      switch (field.type) {
+        case "boolean":
+          return typeof fieldValue === "boolean";
+        case "enum":
+          return typeof fieldValue === "string" && !!field.options?.includes(fieldValue);
+        case "integer":
+        case "float":
+          return typeof fieldValue === "number";
+        case "string":
+          return typeof fieldValue === "string";
+        default:
+          return false;
+      }
+    });
   }
 
   private _complexFieldDefault(
@@ -561,6 +604,12 @@ export class KnxPayloadSelector extends LitElement {
       this._cachedRawLength = this._rawLength;
       this._rawPayload = undefined;
       this._typedValue = this._cachedTypedValue;
+      if (this._typedValue === undefined) {
+        // nothing cached (config was raw from the start) - seed the DPT defaults
+        // so required fields are stored, matching what the selectors display
+        const dpt = this._effectiveDpt();
+        this._typedValue = this._typedValueForDpt(dpt ? this.knx.dptMetadata[dpt] : undefined);
+      }
     }
     this._mode = nextMode;
     this._emitValue();
@@ -622,9 +671,11 @@ export class KnxPayloadSelector extends LitElement {
       const main = Number.parseInt(dpt.split(".")[0], 10);
       if (isApciPackedDptMain(main)) {
         // DPT 1.x, 2.x, and 3.x use payload_length 0 to indicate payload integrated in APDU header
+        // their reported payload_length is a bit count, so the max raw value
+        // is 2**bits - 1 (1 for DPT 1.x, 3 for DPT 2.x, 15 for DPT 3.x)
         const dptLength = this.knx.dptMetadata[dpt]?.payload_length;
         if (dptLength !== undefined) {
-          return BigInt(dptLength);
+          return 2n ** BigInt(dptLength) - 1n;
         }
         return 63n;
       }

--- a/src/components/knx-select-options-list.test.ts
+++ b/src/components/knx-select-options-list.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { KnxSelectOptionsList } from "./knx-select-options-list";
+import type { ErrorDescription } from "../types/entity_data";
+
+const error = (path: string[] | null, message: string): ErrorDescription => ({
+  path,
+  message,
+  code: null,
+});
+
+describe("KnxSelectOptionsList", () => {
+  let element: KnxSelectOptionsList;
+
+  beforeEach(() => {
+    element = new KnxSelectOptionsList();
+    element.hass = { localize: (key: string) => key } as any;
+    element.knx = { dptMetadata: {} } as any;
+  });
+
+  describe("_optionValidationErrors", () => {
+    // options are validated as a list, so the backend indexes their errors by
+    // position - e.g. `custom_options[1].option` arrives as path ["1", "option"]
+    beforeEach(() => {
+      element.validationErrors = [
+        error(["1", "option"], "Option name is required"),
+        error(["2", "value"], "Invalid payload"),
+        error(["2"], "Each option must be a dictionary"),
+        error([], "At least one option is required"),
+      ];
+    });
+
+    it("routes the name error to the option it belongs to", () => {
+      const { name } = (element as any)._optionValidationErrors(1);
+      expect(name?.message).toBe("Option name is required");
+    });
+
+    it("does not leak an option's error to its siblings", () => {
+      expect((element as any)._optionValidationErrors(0)).toEqual({
+        name: undefined,
+        payload: undefined,
+      });
+    });
+
+    it("keeps the name error out of the payload subtree", () => {
+      const { payload } = (element as any)._optionValidationErrors(1);
+      expect(payload).toBeUndefined();
+    });
+
+    it("passes payload and option base errors to the payload selector", () => {
+      const { name, payload } = (element as any)._optionValidationErrors(2);
+      expect(name).toBeUndefined();
+      expect(payload).toEqual([
+        error(["value"], "Invalid payload"),
+        error([], "Each option must be a dictionary"),
+      ]);
+    });
+
+    it("leaves the list base error to the list itself", () => {
+      // the base error has an empty path, so no index matches it
+      for (const index of [0, 1, 2]) {
+        const { name, payload } = (element as any)._optionValidationErrors(index);
+        expect(name?.message).not.toBe("At least one option is required");
+        expect(payload ?? []).not.toContainEqual(
+          expect.objectContaining({ message: "At least one option is required" }),
+        );
+      }
+    });
+
+    it("returns nothing when there are no errors", () => {
+      element.validationErrors = undefined;
+      expect((element as any)._optionValidationErrors(0)).toEqual({
+        name: undefined,
+        payload: undefined,
+      });
+    });
+  });
+});

--- a/src/components/knx-select-options-list.ts
+++ b/src/components/knx-select-options-list.ts
@@ -18,7 +18,7 @@ import type { HomeAssistant } from "@ha/types";
 
 import "./knx-payload-selector";
 import type { PayloadConfigValue } from "./knx-payload-selector";
-import { getValidationError } from "../utils/validation";
+import { extractValidationErrors, getValidationError } from "../utils/validation";
 import type { ErrorDescription } from "../types/entity_data";
 import type { KNX } from "../types/knx";
 
@@ -152,6 +152,7 @@ export class KnxSelectOptionsList extends LitElement {
   // complete, no matter whether the list itself is required.
   private _renderOption(option: SelectOption, index: number, canDelete: boolean): TemplateResult {
     const { option: name, ...payload } = option;
+    const { name: nameError, payload: payloadErrors } = this._optionValidationErrors(index);
     return html`<div class="option">
       <div class="option-header">
         <ha-input
@@ -160,6 +161,8 @@ export class KnxSelectOptionsList extends LitElement {
           .label=${this._localize("option")}
           .type=${"text"}
           .required=${true}
+          .invalid=${!!nameError}
+          .validationMessage=${nameError?.message}
           data-index=${index}
           @input=${this._optionNameChanged}
           @change=${this._optionNameChanged}
@@ -182,11 +185,29 @@ export class KnxSelectOptionsList extends LitElement {
         .rawLength=${this._effectiveDpt ? undefined : this._payloadLength}
         .required=${true}
         .value=${payload as PayloadConfigValue}
+        .validationErrors=${payloadErrors}
         .localizeFunction=${this._emptyLocalize}
         data-index=${index}
         @value-changed=${this._payloadChanged}
       ></knx-payload-selector>
     </div>`;
+  }
+
+  /** Backend errors for one option, split into the name error and the payload subtree.
+   *
+   * Options are validated as a list, so their errors are indexed by position.
+   * The name is validated alongside the payload keys, both below that index.
+   */
+  private _optionValidationErrors(index: number): {
+    name?: ErrorDescription;
+    payload?: ErrorDescription[];
+  } {
+    const errors = extractValidationErrors(this.validationErrors, String(index));
+    const payload = errors?.filter((error) => error.path?.[0] !== "option");
+    return {
+      name: getValidationError(errors, "option"),
+      payload: payload?.length ? payload : undefined,
+    };
   }
 
   private _emptyLocalize = (_key: string): string => "";


### PR DESCRIPTION
Fixes #451

The backend reports `payload_length` of APCI-packed DPTs (main 1, 2 and 3) as a **bit count** — those DPTs are integrated in the APDU header, so `raw_payload_length()` uses `0` for their `RawValue` length. `knx-payload-selector` used that bit count in two places where a value was expected, and reset complex typed values more eagerly than intended.

Reported for a Gira forced-position object on DPT 2.008 (`Direction1Control`), where the three usable states are `control=false,value=up` → 0, `control=true,value=up` → 2 and `control=true,value=down` → 3.

### Raw mode

- `_rawPayloadMax()` returned the bit count itself, capping the raw payload of DPT 2.x at `2` instead of `3` and DPT 3.x at `4` instead of `15` (DPT 1.x was correct by coincidence). Entering a valid `0x3` was *silently* clamped down to `0x2` by `_clampRawPayload()`. It now returns `2**bits - 1`, which fixes the hint, the input bounds, the out-of-range message and the clamping in one go.
- `_applyDptTypedDefaults()` stored the reported length unclamped as the raw payload length, so a raw DPT 2.x payload was emitted with `payload_length: 2` where the backend expects `0` for `DPTBinary` — HA would send a 2 byte `DPTArray` instead of the APCI-embedded bits. `_setRawPayloadAndLengthFromCache()` already clamped; this path now does too.

### Typed mode

Two ways to lose the control-off state of a complex DPT — the state that makes DPT 2.008 raw value 0 selectable:

- `_typedValueForDpt()` reset complex values to the DPT defaults unconditionally. Lit reports `dpt` as changed on the first update too, so merely opening an existing config overwrote every stored value — a saved `{control: true, value: "down"}` became `{control: false, value: "up"}` and was re-emitted into the config. Values are now kept when they still fit the DPT's field schema and merged onto the defaults, so missing required fields are filled in — the same way enum values were already handled. A new `_complexValueFitsSchema()` still resets correctly when the shape differs (2.001 `on`/`off` → 2.008 `up`/`down`, or DPT 3's `step_code`). The redundant-update guard now compares structurally, so a repeated DPT notification with an unchanged value no longer re-emits.
- Switching from raw to typed mode restored `_cachedTypedValue`, which is `undefined` when the config was raw from the start (e.g. options filled in before the group address DPT was picked). Nothing was emitted, so no `control` key was stored while `knx-selector-row` rendered the required boolean as its default — visually "off". That is the reported "only works after toggling the Control switch on and off". The DPT defaults are now seeded on entering typed mode.

### Tests

Adds `knx-payload-selector.test.ts` — first coverage for this component, following the existing `group-monitor-view.test.ts` pattern. 16 tests over `_rawPayloadMax`, `_clampRawPayload`, `_typedValueForDpt`, `_applyDptTypedDefaults` and `_modeChanged`.

Not yet verified end-to-end against a running instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
