### PR TITLE
feat(group-monitor): show filter counts relative to active facets

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "stacktrace-js": "2.0.2",
     "superstruct": "2.0.2",
     "tinykeys": "patch:tinykeys@npm%3A4.0.0#~/homeassistant-frontend/.yarn/patches/tinykeys-npm-4.0.0-a6ca3fd771.patch",
+    "typedfastbitset": "0.8.0",
     "weekstart": "2.0.0",
     "workbox-cacheable-response": "7.4.1",
     "workbox-core": "7.4.1",

--- a/src/features/group-monitor/controller/group-monitor-controller-cross-filter.test.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller-cross-filter.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TelegramDict } from "../../../types/websocket";
+import { getGroupMonitorInfo, queryTelegrams } from "../../../services/websocket.service";
+import { GroupMonitorController } from "./group-monitor-controller";
+
+vi.mock("../../../services/websocket.service", () => ({
+  getGroupMonitorInfo: vi.fn(),
+  queryTelegrams: vi.fn(),
+}));
+
+const telegram = (timestamp: string, source: string, direction: string): TelegramDict => ({
+  timestamp,
+  source,
+  source_name: source,
+  destination: "1/1/1",
+  destination_name: "Light",
+  telegramtype: "GroupValueWrite",
+  direction,
+  payload: [1],
+  dpt_main: 1,
+  dpt_sub: 1,
+  dpt_name: "Switch",
+  unit: null,
+  value: "On",
+});
+
+const createMockHost = () => ({
+  addController: vi.fn(),
+  requestUpdate: vi.fn(),
+});
+
+const createMockTelegramDict = (overrides?: Partial<TelegramDict>): TelegramDict => ({
+  ...telegram("2024-01-01T10:00:00.000Z", "1.1.1", "Incoming"),
+  ...overrides,
+});
+
+describe("GroupMonitorController cross-filtering", () => {
+  let controller: GroupMonitorController;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T10:10:00.000Z"));
+    vi.mocked(queryTelegrams).mockReset();
+    controller = new GroupMonitorController({
+      addController: vi.fn(),
+      requestUpdate: vi.fn(),
+    } as any);
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it.each(["live", "historical"] as const)(
+    "keeps duplicate %s arrivals idempotent through eviction",
+    (arrival) => {
+      const oldest = telegram("2024-01-01T10:00:00.000Z", "1.1.1", "Incoming");
+      const middle = telegram("2024-01-01T10:00:01.000Z", "1.1.2", "Incoming");
+      const newest = telegram("2024-01-01T10:00:02.000Z", "1.1.3", "Incoming");
+
+      if (arrival === "live") {
+        (controller as any)._telegramBuffer.setMaxSize(2);
+        (controller as any)._handleIncomingTelegram(oldest);
+        (controller as any)._handleIncomingTelegram({ ...oldest });
+      } else {
+        controller.addHistoricalTelegrams([oldest, { ...oldest }], false);
+        (controller as any)._telegramBuffer.setMaxSize(2);
+      }
+
+      for (const [next, sources] of [
+        [null, ["1.1.1"]],
+        [middle, ["1.1.1", "1.1.2"]],
+        [newest, ["1.1.2", "1.1.3"]],
+      ] as const) {
+        if (next) (controller as any)._handleIncomingTelegram(next);
+        const result = controller.getFilteredTelegramsAndDistinctValues();
+        expect.soft(controller.telegrams.map((row) => row.sourceAddress)).toEqual(sources);
+        expect
+          .soft(result.filteredTelegrams.map((row) => row.sourceAddress).sort())
+          .toEqual(sources);
+        expect.soft(Object.keys(result.distinctValues.source).sort()).toEqual(sources);
+        for (const source of sources) {
+          expect.soft(result.distinctValues.source[source]?.crossFilteredCount).toBe(1);
+        }
+        for (const values of Object.values(result.distinctValues)) {
+          expect
+            .soft(Object.values(values).reduce((sum, value) => sum + value.crossFilteredCount, 0))
+            .toBe(sources.length);
+        }
+      }
+    },
+  );
+
+  it("scopes cross-counts before adding time-delta context", async () => {
+    const match = telegram("2024-01-01T10:00:00.000Z", "1.1.1", "Incoming");
+    const contextAfter = telegram("2024-01-01T10:00:00.300Z", "1.1.2", "Outgoing");
+    const contextBefore = telegram("2024-01-01T09:59:59.000Z", "1.1.3", "Incoming");
+    const liveOutside = telegram("2024-01-01T10:02:00.000Z", "1.1.4", "Incoming");
+
+    vi.mocked(getGroupMonitorInfo).mockResolvedValueOnce({
+      project_loaded: true,
+      recent_telegrams: [match, contextAfter],
+    } as any);
+    await controller.reload({} as any);
+    controller.addHistoricalTelegrams([contextBefore], false);
+    (controller as any)._handleIncomingTelegram(liveOutside);
+
+    await controller.applyTimeRangeFilter(
+      {} as any,
+      new Date("2024-01-01T10:00:00.000Z").getTime(),
+      new Date("2024-01-01T10:00:01.000Z").getTime(),
+      null,
+    );
+    controller.setFilterFieldValue("source", ["1.1.1"]);
+    controller.setFilterFieldValue("direction", ["Incoming"]);
+    controller.setTimeDelta(1500, 500);
+
+    const result = controller.getFilteredTelegramsAndDistinctValues();
+
+    expect(result.filteredTelegrams.map((row) => row.sourceAddress).sort()).toEqual([
+      "1.1.1",
+      "1.1.2",
+      "1.1.3",
+    ]);
+    expect(result.timeDeltaAddedCount).toBe(2);
+    expect(result.distinctValues.source["1.1.1"].crossFilteredCount).toBe(1);
+    expect(result.distinctValues.source["1.1.2"].crossFilteredCount).toBe(0);
+    expect(result.distinctValues.source["1.1.3"].crossFilteredCount).toBe(0);
+    expect(result.distinctValues.source["1.1.4"].crossFilteredCount).toBe(0);
+    expect(result.distinctValues.direction.Incoming.crossFilteredCount).toBe(1);
+    expect(result.distinctValues.direction.Outgoing.crossFilteredCount).toBe(0);
+  });
+
+  it("does not index an old live telegram evicted from a full buffer", async () => {
+    const survivor = telegram("2024-01-01T10:00:00.000Z", "1.1.1", "Incoming");
+    const evicted = telegram("2024-01-01T09:59:00.000Z", "1.1.2", "Incoming");
+
+    vi.mocked(getGroupMonitorInfo).mockResolvedValueOnce({
+      project_loaded: true,
+      recent_telegrams: [survivor],
+    } as any);
+    await controller.reload({} as any);
+    (controller as any)._telegramBuffer.setMaxSize(1);
+    (controller as any)._handleIncomingTelegram(evicted);
+
+    const result = controller.getFilteredTelegramsAndDistinctValues();
+
+    expect(result.filteredTelegrams.map((row) => row.sourceAddress)).toEqual(["1.1.1"]);
+    expect(result.distinctValues.source["1.1.1"].crossFilteredCount).toBe(1);
+    expect(result.distinctValues.source["1.1.2"]).toBeUndefined();
+  });
+
+  it("ignores duplicate live telegrams without incrementing version or updating host", async () => {
+    const host = createMockHost();
+    const localController = new GroupMonitorController(host as any);
+    const cacheStoreSpy = vi.spyOn(localController as any, "_cacheStore");
+    (localController as any)._isPaused = false;
+    const initialVersion = (localController as any)._bufferVersion;
+
+    const rawTelegram = createMockTelegramDict({
+      timestamp: "2024-01-01T10:00:00.000Z",
+      source: "1.1.1",
+      destination: "1/1/1",
+    });
+
+    (localController as any)._handleIncomingTelegram(rawTelegram);
+    expect((localController as any)._bufferVersion).toBe(initialVersion + 1);
+    expect(host.requestUpdate).toHaveBeenCalledTimes(1);
+    expect(cacheStoreSpy).toHaveBeenCalledTimes(1);
+
+    // Send duplicate
+    (host.requestUpdate as any).mockClear();
+    cacheStoreSpy.mockClear();
+    (localController as any)._handleIncomingTelegram(rawTelegram);
+
+    expect((localController as any)._bufferVersion).toBe(initialVersion + 1);
+    expect(host.requestUpdate).not.toHaveBeenCalled();
+    expect(cacheStoreSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["clearing rows", () => controller.clearTelegrams()],
+    ["clearing the cache", () => controller.clearCache()],
+  ])("preserves selected source and destination labels when %s", async (_action, clear) => {
+    controller.addHistoricalTelegrams(
+      [
+        createMockTelegramDict({
+          source: "1.1.10",
+          source_name: "Kitchen switch",
+          destination: "2/3/4",
+          destination_name: "Kitchen light",
+        }),
+      ],
+      false,
+    );
+    controller.setFilterFieldValue("source", ["1.1.10"]);
+    controller.setFilterFieldValue("destination", ["2/3/4"]);
+
+    await clear();
+
+    const { filteredTelegrams, distinctValues } =
+      controller.getFilteredTelegramsAndDistinctValues();
+    expect(filteredTelegrams).toEqual([]);
+    expect(distinctValues.source["1.1.10"]).toEqual({
+      id: "1.1.10",
+      name: "Kitchen switch",
+      crossFilteredCount: 0,
+    });
+    expect(distinctValues.destination["2/3/4"]).toEqual({
+      id: "2/3/4",
+      name: "Kitchen light",
+      crossFilteredCount: 0,
+    });
+  });
+});

--- a/src/features/group-monitor/controller/group-monitor-controller-cross-filter.test.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller-cross-filter.test.ts
@@ -148,6 +148,24 @@ describe("GroupMonitorController cross-filtering", () => {
     expect(result.distinctValues.source["1.1.2"]).toBeUndefined();
   });
 
+  it("does not index an old recent telegram evicted during reload", async () => {
+    const survivor = telegram("2024-01-01T10:00:00.000Z", "1.1.1", "Incoming");
+    const evicted = telegram("2024-01-01T09:59:00.000Z", "1.1.2", "Incoming");
+    (controller as any)._calculateTelegramStorageBuffer = vi.fn().mockReturnValue(0);
+
+    vi.mocked(getGroupMonitorInfo)
+      .mockResolvedValueOnce({ project_loaded: true, recent_telegrams: [survivor] } as any)
+      .mockResolvedValueOnce({ project_loaded: true, recent_telegrams: [evicted] } as any);
+    await controller.reload({} as any);
+    await controller.reload({} as any);
+
+    const result = controller.getFilteredTelegramsAndDistinctValues();
+
+    expect(result.filteredTelegrams.map((row) => row.sourceAddress)).toEqual(["1.1.1"]);
+    expect(result.distinctValues.source["1.1.1"].crossFilteredCount).toBe(1);
+    expect(result.distinctValues.source["1.1.2"]).toBeUndefined();
+  });
+
   it("ignores duplicate live telegrams without incrementing version or updating host", async () => {
     const host = createMockHost();
     const localController = new GroupMonitorController(host as any);

--- a/src/features/group-monitor/controller/group-monitor-controller-dpt.test.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller-dpt.test.ts
@@ -93,7 +93,12 @@ describe("GroupMonitorController - DPT Filtering & URL Syncing", () => {
       await injectTelegrams([
         createMockTelegram({ dpt_main: 1, dpt_sub: 1, source: "1.1.1" }),
         createMockTelegram({ dpt_main: 1, dpt_sub: 1, source: "1.1.2" }),
-        createMockTelegram({ dpt_main: 5, dpt_sub: 1, source: "1.1.1" }),
+        createMockTelegram({
+          timestamp: "2024-01-01T10:00:01.000Z",
+          dpt_main: 5,
+          dpt_sub: 1,
+          source: "1.1.1",
+        }),
       ]);
 
       controller.setFilterFieldValue("dpt", ["1.001"]);
@@ -117,8 +122,8 @@ describe("GroupMonitorController - DPT Filtering & URL Syncing", () => {
       const { distinctValues } = controller.getFilteredTelegramsAndDistinctValues();
 
       expect(distinctValues.dpt[UNKNOWN_DPT_ID]).toBeDefined();
-      expect(distinctValues.dpt[UNKNOWN_DPT_ID].totalCount).toBe(2);
-      expect(distinctValues.dpt["1.001"].totalCount).toBe(1);
+      expect(distinctValues.dpt[UNKNOWN_DPT_ID].crossFilteredCount).toBe(2);
+      expect(distinctValues.dpt["1.001"].crossFilteredCount).toBe(1);
     });
 
     it("should filter for telegrams without DPT", async () => {

--- a/src/features/group-monitor/controller/group-monitor-controller-historical.test.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller-historical.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { TelegramDict } from "../../../types/websocket";
 import { GroupMonitorController } from "./group-monitor-controller";
-import { TelegramRow } from "../types/telegram-row";
 import { getGroupMonitorInfo } from "../../../services/websocket.service";
 
 vi.mock("../../../services/websocket.service", () => ({
@@ -157,14 +156,9 @@ describe("GroupMonitorController - Historical Telegrams", () => {
     // Wait, if I want it to evict, I need to ensure the limit stays 10.
 
     // Add 1 newer telegram - this should trigger eviction of the oldest initial telegram
-    const newRow = new TelegramRow(
+    (controller as any)._handleIncomingTelegram(
       createMockTelegram({ timestamp: "2024-01-01T13:00:00.000Z", source: "1.2.1" }),
     );
-    (controller as any)._addToDistinctValues(newRow);
-    const removed = (controller as any)._telegramBuffer.add(newRow);
-    if (removed.length > 0) {
-      (controller as any)._removeFromDistinctValues(removed);
-    }
 
     const result = controller.getFilteredTelegramsAndDistinctValues();
     expect(result.filteredTelegrams).toHaveLength(10);

--- a/src/features/group-monitor/controller/group-monitor-controller.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller.ts
@@ -1120,7 +1120,7 @@ export class GroupMonitorController implements ReactiveController {
       }
 
       // A just-added telegram can also overflow immediately when the buffer is full.
-      this._facetIndex.update(removed.includes(telegramRow) ? [] : added, removed);
+      this._facetIndex.update(added, removed);
       this._bufferVersion++;
 
       // Persist live telegram to IndexedDB cache.

--- a/src/features/group-monitor/controller/group-monitor-controller.ts
+++ b/src/features/group-monitor/controller/group-monitor-controller.ts
@@ -11,6 +11,15 @@ import { TelegramBufferService } from "../services/telegram-buffer-service";
 import { TelegramCoverageService } from "../services/telegram-coverage-service";
 import { TelegramCacheService, MAX_CACHE_SIZE } from "../services/telegram-cache-service";
 import { ConnectionService } from "../services/connection-service";
+import {
+  FacetIndex,
+  FILTER_FIELDS,
+  UNKNOWN_DPT_ID,
+  type DistinctValues,
+  type FilterField,
+  type FilterMap,
+  type DistinctValueInfo,
+} from "../services/facet-index";
 import { KNXLogger } from "../../../tools/knx-logger";
 import { TelegramRow, type OffsetMicros } from "../types/telegram-row";
 import type { TelegramDict } from "../../../types/websocket";
@@ -18,35 +27,8 @@ import { extractMicrosecondsFromIso } from "../../../utils/format";
 
 const logger = new KNXLogger("group_monitor_controller");
 
-// Filter and distinct values types for type safety
-export type FilterField = "source" | "destination" | "direction" | "telegramtype" | "dpt";
-
-// All filter fields as a constant array
-export const FILTER_FIELDS: readonly FilterField[] = [
-  "source",
-  "destination",
-  "direction",
-  "telegramtype",
-  "dpt",
-] as const;
-
-/**
- * Sentinel filter id for telegrams without a DPT (no project data or
- * unknown group address). Kept URL-safe and distinct from real DPT ids,
- * which are always numeric (e.g. "1.001").
- */
-export const UNKNOWN_DPT_ID = "unknown";
-
-export type FilterMap = Record<FilterField, ReadonlySet<string>>;
-
-export interface DistinctValueInfo {
-  id: string;
-  name: string;
-  totalCount: number;
-  filteredCount?: number;
-}
-
-export type DistinctValues = Record<FilterField, Record<string, DistinctValueInfo>>;
+export { FILTER_FIELDS, UNKNOWN_DPT_ID };
+export type { DistinctValues, FilterField, FilterMap, DistinctValueInfo };
 
 /**
  * Combined result of telegram filtering and distinct values calculation
@@ -136,14 +118,8 @@ export class GroupMonitorController implements ReactiveController {
   // Monotonic id to discard results of superseded history requests
   private _historyRequestId = 0;
 
-  // Filter data - only stores total counts, filtered counts computed on-the-fly
-  private _distinctValues: DistinctValues = {
-    source: {},
-    destination: {},
-    direction: {},
-    telegramtype: {},
-    dpt: {},
-  };
+  /** Bitset-backed filter index kept in sync with the telegram buffer. */
+  private _facetIndex = new FacetIndex();
 
   // Buffer version counter for memoization cache invalidation
   private _bufferVersion = 0;
@@ -325,7 +301,6 @@ export class GroupMonitorController implements ReactiveController {
       this._bufferVersion,
       JSON.stringify(this._filters),
       this._telegramBuffer.snapshot,
-      this._distinctValues,
       this._sortColumn,
       this._sortDirection,
       this._timeDeltaBefore,
@@ -351,16 +326,22 @@ export class GroupMonitorController implements ReactiveController {
     return result;
   }
 
-  /**
-   * Combined computation of filtered telegrams and distinct values with filtered counts
-   * Ensures both states are always synchronized and computed together
-   */
+  /** Converts the mutable UI filter state into the FacetIndex query contract. */
+  private _createFilterMap(): FilterMap {
+    return {
+      source: new Set(this._filters.source ?? []),
+      destination: new Set(this._filters.destination ?? []),
+      direction: new Set(this._filters.direction ?? []),
+      telegramtype: new Set(this._filters.telegramtype ?? []),
+      dpt: new Set(this._filters.dpt ?? []),
+    };
+  }
+
   private _getFilteredTelegramsAndDistinctValues = memoize(
     (
       _bufferVersion: number,
       _filtersJson: string,
       allTelegrams: readonly TelegramRow[],
-      distinctValues: DistinctValues,
       sortColumn?: string,
       sortDirection?: SortingDirection,
       timeDeltaBefore?: number,
@@ -368,15 +349,27 @@ export class GroupMonitorController implements ReactiveController {
       filterStartMs?: number,
       filterEndMs?: number,
     ): FilteredTelegramsResult => {
-      // Filter telegrams based on the active list filters and time range
-      const matchingTelegrams = allTelegrams.filter((telegram) => {
-        if (filterStartMs !== undefined || filterEndMs !== undefined) {
-          const ts = telegram.timestamp.getTime();
-          if (filterStartMs !== undefined && ts < filterStartMs) return false;
-          if (filterEndMs !== undefined && ts > filterEndMs) return false;
-        }
-        return this.matchesActiveFilters(telegram);
+      const scope = allTelegrams.filter((telegram) => {
+        const ts = telegram.timestamp.getTime();
+        return !(
+          (filterStartMs !== undefined && ts < filterStartMs) ||
+          (filterEndMs !== undefined && ts > filterEndMs)
+        );
       });
+
+      const filtersMap = this._createFilterMap();
+
+      const isFullScope =
+        filterStartMs === undefined &&
+        filterEndMs === undefined &&
+        scope.length === allTelegrams.length;
+
+      // Derive the visible rows and all cross-filter counts from the same index snapshot.
+      const { matchingTelegrams, distinctValues } = this._facetIndex.query(
+        scope,
+        filtersMap,
+        isFullScope,
+      );
 
       // Apply time-delta expansion if active
       const filteredTelegrams = this._applyTimeDeltaExpansion(
@@ -433,29 +426,7 @@ export class GroupMonitorController implements ReactiveController {
         });
       }
 
-      // Create a deep copy of distinct values with filtered counts initialized to 0
-      const distinctValuesWithFilteredCounts: DistinctValues = {
-        source: {},
-        destination: {},
-        direction: {},
-        telegramtype: {},
-        dpt: {},
-      };
-
-      // Initialize all distinct values with filteredCount = 0
-      const fields = Object.keys(distinctValues) as FilterField[];
-      for (const field of fields) {
-        for (const [id, info] of Object.entries(distinctValues[field])) {
-          distinctValuesWithFilteredCounts[field][id] = {
-            id: info.id,
-            name: info.name,
-            totalCount: info.totalCount,
-            filteredCount: 0,
-          };
-        }
-      }
-
-      // Count filtered occurrences and calculate offsets in the same loop
+      // Calculate offsets in the same loop.
       for (let i = 0; i < filteredTelegrams.length; i++) {
         const telegram = filteredTelegrams[i];
 
@@ -479,23 +450,11 @@ export class GroupMonitorController implements ReactiveController {
           // For non-timestamp sorting, reset offset to null
           telegram.offset = null;
         }
-
-        // Count distinct values
-        for (const field of fields) {
-          const extracted = this._extractTelegramField(telegram, field);
-          if (!extracted) continue;
-
-          const { id } = extracted;
-          const distinctValue = distinctValuesWithFilteredCounts[field][id];
-          if (distinctValue) {
-            distinctValue.filteredCount = (distinctValue.filteredCount || 0) + 1;
-          }
-        }
       }
 
       return {
         filteredTelegrams,
-        distinctValues: distinctValuesWithFilteredCounts,
+        distinctValues,
         timeDeltaAddedCount,
       };
     },
@@ -504,25 +463,6 @@ export class GroupMonitorController implements ReactiveController {
   // ============================================================================
   // Filter methods
   // ============================================================================
-
-  /**
-   * Determines if a telegram matches the currently active filters
-   */
-  public matchesActiveFilters(telegram: TelegramRow): boolean {
-    return Object.entries(this._filters).every(([field, values]) => {
-      if (!values?.length) return true;
-
-      const fieldMap: Record<string, string | null> = {
-        source: telegram.sourceAddress,
-        destination: telegram.destinationAddress,
-        direction: telegram.direction,
-        telegramtype: telegram.type,
-        dpt: telegram.dptId ?? UNKNOWN_DPT_ID,
-      };
-
-      return values.includes(fieldMap[field] || "");
-    });
-  }
 
   /**
    * Toggles a filter value on/off for a specific field
@@ -541,7 +481,6 @@ export class GroupMonitorController implements ReactiveController {
     this._resetTimeDeltaIfNoListFilters();
 
     this._updateUrlFromFilters(route);
-    this._cleanupUnusedFilterValues();
 
     this.host.requestUpdate();
   }
@@ -555,7 +494,6 @@ export class GroupMonitorController implements ReactiveController {
     this._resetTimeDeltaIfNoListFilters();
 
     this._updateUrlFromFilters(route);
-    this._cleanupUnusedFilterValues();
 
     this.host.requestUpdate();
   }
@@ -569,7 +507,6 @@ export class GroupMonitorController implements ReactiveController {
     this._timeDeltaAfter = 0;
     this.clearTimeRangeFilter();
     this._updateUrlFromFilters(route);
-    this._cleanupUnusedFilterValues();
 
     this.host.requestUpdate();
   }
@@ -824,9 +761,8 @@ export class GroupMonitorController implements ReactiveController {
     } catch {
       // ignore
     }
-    const cleared = this._telegramBuffer.clear();
-    if (cleared.length > 0) {
-      this._resetDistinctValues();
+    if (this._telegramBuffer.clear().length > 0) {
+      this._facetIndex.clear(this._createFilterMap());
     }
     this._isReloadEnabled = true;
     this._bufferVersion++;
@@ -890,10 +826,6 @@ export class GroupMonitorController implements ReactiveController {
   }
 
   /**
-   * Adds historical telegrams fetched from the backend.
-   * Merges them with existing telegrams and updates the buffer size.
-   */
-  /**
    * Adds historical telegrams fetched from the backend (or restored from the
    * persistent cache) into the in-memory buffer.
    *
@@ -910,28 +842,23 @@ export class GroupMonitorController implements ReactiveController {
     const buffer = this._calculateTelegramStorageBuffer(telegramsLength);
     const telegramStorageLimit = Math.max(this._telegramBuffer.maxSize, telegramsLength + buffer);
 
-    // Update max telegram count if needed
+    let resizedOut: TelegramRow[] = [];
     if (this._telegramBuffer.maxSize !== telegramStorageLimit) {
-      const removedTelegrams = this._telegramBuffer.setMaxSize(telegramStorageLimit);
-      if (removedTelegrams.length > 0) {
-        this._removeFromDistinctValues(removedTelegrams);
-      }
+      resizedOut = this._telegramBuffer.setMaxSize(telegramStorageLimit);
     }
 
     // Merge new telegrams with existing ones, avoiding duplicates
     const newTelegramRows = telegrams.map((t) => new TelegramRow(t));
     const { added, removed } = this._telegramBuffer.merge(newTelegramRows);
 
-    // Update distinct values incrementally
-    if (removed.length > 0) {
-      this._removeFromDistinctValues(removed);
+    // Keep the index aligned with both size-driven and merge-driven buffer removals.
+    const allRemoved = [...resizedOut, ...removed];
+    if (added.length > 0 || allRemoved.length > 0) {
+      this._facetIndex.update(added, allRemoved);
+      this._bufferVersion++;
     }
 
     if (added.length > 0) {
-      for (const telegram of added) {
-        this._addToDistinctValues(telegram);
-      }
-
       // Persist newly-added dicts (skip when caller is the cache restore path).
       if (persist) {
         const addedIds = new Set(added.map((r) => r.id));
@@ -950,15 +877,12 @@ export class GroupMonitorController implements ReactiveController {
     this.host.requestUpdate();
   }
 
-  /**
-   * Clears all telegrams from the display and resets filter data
-   */
+  /** Clears all telegrams from the display. */
   public clearTelegrams(): void {
-    // Create filtered distinct values to preserve selected filter names
-    const preserveValues = this._createFilteredDistinctValues();
-
-    this._telegramBuffer.clear();
-    this._resetDistinctValues(preserveValues);
+    if (this._telegramBuffer.clear().length > 0) {
+      this._facetIndex.clear(this._createFilterMap());
+      this._bufferVersion++;
+    }
     this._isReloadEnabled = true;
     this.host.requestUpdate();
   }
@@ -988,32 +912,6 @@ export class GroupMonitorController implements ReactiveController {
     // Always calculate the time difference to get positive values
     // For both sort directions, we now pass the chronologically earlier telegram as "previous"
     return currentMicros - previousMicros;
-  }
-
-  /**
-   * Extracts field value for distinct value tracking
-   */
-  private _extractTelegramField(
-    telegram: TelegramRow,
-    field: FilterField,
-  ): { id: string; name: string } | null {
-    switch (field) {
-      case "source":
-        return { id: telegram.sourceAddress, name: telegram.sourceText || "" };
-      case "destination":
-        return { id: telegram.destinationAddress, name: telegram.destinationText || "" };
-      case "direction":
-        return { id: telegram.direction, name: "" };
-      case "telegramtype":
-        return { id: telegram.type, name: "" };
-      case "dpt":
-        // Telegrams without DPT information are grouped under a sentinel id so
-        // they remain filterable; the display name is resolved by the view.
-        if (!telegram.dptId) return { id: UNKNOWN_DPT_ID, name: "" };
-        return { id: telegram.dptId, name: telegram.dpt || telegram.dptId };
-      default:
-        return null;
-    }
   }
 
   /**
@@ -1089,151 +987,6 @@ export class GroupMonitorController implements ReactiveController {
   }
 
   /**
-   * Adds a telegram to distinct values tracking (total counts only)
-   */
-  private _addToDistinctValues(telegram: TelegramRow): void {
-    for (const field of FILTER_FIELDS) {
-      const extracted = this._extractTelegramField(telegram, field);
-      if (!extracted) {
-        logger.warn(`Unknown field for distinct values: ${field}`);
-        continue;
-      }
-
-      const { id, name } = extracted;
-      if (!this._distinctValues[field][id]) {
-        this._distinctValues[field][id] = {
-          id,
-          name,
-          totalCount: 0,
-        };
-      }
-
-      this._distinctValues[field][id].totalCount++;
-
-      // Update name if it was empty and we have a name
-      if (this._distinctValues[field][id].name === "" && name) {
-        this._distinctValues[field][id].name = name;
-      }
-    }
-
-    // Increment buffer version to invalidate memoization cache
-    this._bufferVersion++;
-  }
-
-  /**
-   * Removes telegrams from distinct values tracking (total counts only)
-   */
-  private _removeFromDistinctValues(telegrams: TelegramRow[]): void {
-    if (telegrams.length === 0) return;
-
-    for (const telegram of telegrams) {
-      for (const field of FILTER_FIELDS) {
-        const extracted = this._extractTelegramField(telegram, field);
-        if (!extracted) continue;
-
-        const { id } = extracted;
-        const distinctValue = this._distinctValues[field][id];
-        if (!distinctValue) continue;
-
-        distinctValue.totalCount--;
-
-        // Remove entry if total count reaches zero
-        if (distinctValue.totalCount <= 0) {
-          delete this._distinctValues[field][id];
-        }
-      }
-    }
-
-    // Increment buffer version to invalidate memoization cache
-    this._bufferVersion++;
-  }
-
-  /**
-   * Creates a TelegramDistinctValues object with selected filter values and their names
-   * All counts are initialized to 0
-   */
-  private _createFilteredDistinctValues(): DistinctValues {
-    const result: DistinctValues = {
-      source: {},
-      destination: {},
-      direction: {},
-      telegramtype: {},
-      dpt: {},
-    };
-
-    for (const field of FILTER_FIELDS) {
-      const filterValues = this._filters[field];
-      if (!filterValues?.length) continue;
-
-      for (const value of filterValues) {
-        const existingInfo = this._distinctValues[field][value];
-        result[field][value] = {
-          id: value,
-          name: existingInfo?.name || "",
-          totalCount: 0,
-        };
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Removes distinct values with totalCount 0 that are no longer in active filters
-   * This cleans up filter values that were preserved but are no longer selected
-   */
-  private _cleanupUnusedFilterValues(): void {
-    let hasChanges = false;
-
-    for (const field of FILTER_FIELDS) {
-      const activeFilterValues = this._filters[field] || [];
-      const fieldValues = this._distinctValues[field];
-
-      for (const [value, info] of Object.entries(fieldValues)) {
-        // Remove if totalCount is 0 and value is not in active filters
-        if (info.totalCount === 0 && !activeFilterValues.includes(value)) {
-          delete this._distinctValues[field][value];
-          hasChanges = true;
-        }
-      }
-    }
-
-    // Increment buffer version if we made changes
-    if (hasChanges) {
-      this._bufferVersion++;
-    }
-  }
-
-  /**
-   * Resets all distinct values
-   * @param preserveValues - Optional DistinctValues to preserve with their names
-   */
-  private _resetDistinctValues(preserveValues?: DistinctValues): void {
-    if (preserveValues) {
-      // Start with the preserved values
-      this._distinctValues = {
-        source: { ...preserveValues.source },
-        destination: { ...preserveValues.destination },
-        direction: { ...preserveValues.direction },
-        telegramtype: { ...preserveValues.telegramtype },
-        dpt: { ...preserveValues.dpt },
-      };
-    } else {
-      // Reset to empty
-      this._distinctValues = {
-        source: {},
-        destination: {},
-        direction: {},
-        telegramtype: {},
-        dpt: {},
-      };
-    }
-
-    // Increment buffer version to invalidate memoization cache
-    this._bufferVersion++;
-  }
-
-  /**
    * Resets time-delta values to 0 if no list filters are active
    */
   private _resetTimeDeltaIfNoListFilters(): void {
@@ -1290,31 +1043,23 @@ export class GroupMonitorController implements ReactiveController {
       const buffer = this._calculateTelegramStorageBuffer(telegramsLength);
       const telegramStorageLimit = telegramsLength + buffer;
 
-      // Update max telegram count if needed
+      let resizedOut: TelegramRow[] = [];
       if (this._telegramBuffer.maxSize !== telegramStorageLimit) {
-        const removedTelegrams = this._telegramBuffer.setMaxSize(telegramStorageLimit);
-
-        // Update distinct values by removing counts for removed telegrams
-        if (removedTelegrams.length > 0) {
-          this._removeFromDistinctValues(removedTelegrams);
-        }
+        resizedOut = this._telegramBuffer.setMaxSize(telegramStorageLimit);
       }
 
       // Merge new telegrams with existing ones, avoiding duplicates
       const newTelegramRows = info.recent_telegrams.map((t) => new TelegramRow(t));
       const { added, removed } = this._telegramBuffer.merge(newTelegramRows);
 
-      // Update distinct values incrementally
-      if (removed.length > 0) {
-        this._removeFromDistinctValues(removed);
+      // Keep the index aligned with both size-driven and merge-driven buffer removals.
+      const allRemoved = [...resizedOut, ...removed];
+      if (added.length > 0 || allRemoved.length > 0) {
+        this._facetIndex.update(added, allRemoved);
+        this._bufferVersion++;
       }
 
       if (added.length > 0) {
-        // Add new telegrams to distinct values incrementally
-        for (const telegram of added) {
-          this._addToDistinctValues(telegram);
-        }
-
         // Persist newly-added recent telegrams to IndexedDB.
         const addedIds = new Set(added.map((r) => r.id));
         const batch = newTelegramRows
@@ -1369,13 +1114,14 @@ export class GroupMonitorController implements ReactiveController {
     const telegramRow = new TelegramRow(telegram);
 
     if (!this._isPaused) {
-      const removedTelegrams = this._telegramBuffer.add(telegramRow);
-      if (removedTelegrams.length > 0) {
-        this._removeFromDistinctValues(removedTelegrams);
+      const { added, removed } = this._telegramBuffer.merge([telegramRow]);
+      if (added.length === 0 && removed.length === 0) {
+        return;
       }
 
-      // Add new telegram to distinct values
-      this._addToDistinctValues(telegramRow);
+      // A just-added telegram can also overflow immediately when the buffer is full.
+      this._facetIndex.update(removed.includes(telegramRow) ? [] : added, removed);
+      this._bufferVersion++;
 
       // Persist live telegram to IndexedDB cache.
       this._cacheStore([
@@ -1457,9 +1203,6 @@ export class GroupMonitorController implements ReactiveController {
       telegramtype: telegramtype ? telegramtype.split(",") : [],
       dpt: dpt ? dpt.split(",") : [],
     };
-
-    const preserveValues = this._createFilteredDistinctValues();
-    this._resetDistinctValues(preserveValues);
 
     this.host.requestUpdate();
   }

--- a/src/features/group-monitor/index.ts
+++ b/src/features/group-monitor/index.ts
@@ -1,11 +1,13 @@
 export { GroupMonitorController } from "./controller/group-monitor-controller";
-export type {
-  FilterField,
-  FilterMap,
-  DistinctValueInfo,
-  DistinctValues,
-  FilteredTelegramsResult,
-} from "./controller/group-monitor-controller";
+export type { FilteredTelegramsResult } from "./controller/group-monitor-controller";
+export {
+  FILTER_FIELDS,
+  UNKNOWN_DPT_ID,
+  type FilterField,
+  type FilterMap,
+  type DistinctValueInfo,
+  type DistinctValues,
+} from "./services/facet-index";
 
 export { TelegramBufferService } from "./services/telegram-buffer-service";
 export { GroupMonitorTelegramInfoDialog } from "./dialogs/telegram-info-dialog";

--- a/src/features/group-monitor/services/facet-index.test.ts
+++ b/src/features/group-monitor/services/facet-index.test.ts
@@ -103,6 +103,14 @@ describe("FacetIndex", () => {
     expect(result.distinctValues.source["1.1.3"].crossFilteredCount).toBe(1);
   });
 
+  it("does not index a row added and removed in the same update", () => {
+    const index = new FacetIndex();
+
+    index.update([a], [a]);
+
+    expect(index.query([], filters()).distinctValues.source["1.1.1"]).toBeUndefined();
+  });
+
   it("enriches an existing facet value when a later telegram supplies its name", () => {
     const index = new FacetIndex();
     const unnamedSource = { ...a, id: "unnamed-source", sourceText: null };

--- a/src/features/group-monitor/services/facet-index.test.ts
+++ b/src/features/group-monitor/services/facet-index.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import { FacetIndex, type FacetTelegram, type FilterMap, UNKNOWN_DPT_ID } from "./facet-index";
+
+const telegram = (
+  id: string,
+  sourceAddress: string,
+  destinationAddress: string,
+  direction: string,
+  type: string,
+  dptId: string | null,
+): FacetTelegram => ({
+  id,
+  sourceAddress,
+  sourceText: `Source ${sourceAddress}`,
+  destinationAddress,
+  destinationText: `Destination ${destinationAddress}`,
+  direction,
+  type,
+  dptId,
+  dpt: dptId,
+});
+
+const filters = (values: Partial<Record<keyof FilterMap, string[]>> = {}): FilterMap => ({
+  source: new Set(values.source),
+  destination: new Set(values.destination),
+  direction: new Set(values.direction),
+  telegramtype: new Set(values.telegramtype),
+  dpt: new Set(values.dpt),
+});
+
+const a = telegram("a", "1.1.1", "1/1/1", "Incoming", "GroupValueWrite", "1.001");
+const b = telegram("b", "1.1.2", "1/1/1", "Incoming", "GroupValueRead", null);
+const c = telegram("c", "1.1.1", "2/2/2", "Outgoing", "GroupValueWrite", "1.001");
+const d = telegram("d", "1.1.3", "2/2/2", "Incoming", "GroupValueWrite", "5.001");
+
+describe("FacetIndex", () => {
+  it("ORs within fields, ANDs across fields, and ignores the counted field", () => {
+    const index = new FacetIndex();
+    index.update([a, b, c, d], []);
+
+    const result = index.query(
+      [a, b, c],
+      filters({ source: ["1.1.1", "1.1.2"], direction: ["Incoming"] }),
+    );
+
+    expect(result.matchingTelegrams.map((row) => row.id)).toEqual(["a", "b"]);
+    expect(result.distinctValues.source["1.1.1"].crossFilteredCount).toBe(1);
+    expect(result.distinctValues.source["1.1.2"].crossFilteredCount).toBe(1);
+    expect(result.distinctValues.source["1.1.3"].crossFilteredCount).toBe(0);
+    expect(result.distinctValues.destination["1/1/1"].crossFilteredCount).toBe(2);
+    expect(result.distinctValues.destination["2/2/2"].crossFilteredCount).toBe(0);
+    expect(result.distinctValues.direction.Incoming.crossFilteredCount).toBe(2);
+    expect(result.distinctValues.direction.Outgoing.crossFilteredCount).toBe(1);
+    expect(result.distinctValues.dpt["1.001"].crossFilteredCount).toBe(1);
+    expect(result.distinctValues.dpt[UNKNOWN_DPT_ID].crossFilteredCount).toBe(1);
+  });
+
+  it("keeps zero-count and selected unknown values visible", () => {
+    const index = new FacetIndex();
+    index.update([a, b, c, d], []);
+
+    const result = index.query([a, b, c, d], filters({ destination: ["9/9/9"] }));
+
+    expect(result.matchingTelegrams).toEqual([]);
+    expect(result.distinctValues.destination["1/1/1"].crossFilteredCount).toBe(2);
+    expect(result.distinctValues.destination["2/2/2"].crossFilteredCount).toBe(2);
+    expect(result.distinctValues.destination["9/9/9"]).toEqual({
+      id: "9/9/9",
+      name: "",
+      crossFilteredCount: 0,
+    });
+  });
+
+  it("does not treat duplicate scope rows as the full indexed scope", () => {
+    const index = new FacetIndex();
+    index.update([a, b], []);
+
+    const result = index.query([a, a], filters());
+
+    expect(result.distinctValues.source["1.1.1"].crossFilteredCount).toBe(1);
+    expect(result.distinctValues.source["1.1.2"].crossFilteredCount).toBe(0);
+  });
+
+  it("updates incrementally, reuses released indices, and ignores duplicates", () => {
+    const index = new FacetIndex();
+    index.update([a, a], []);
+
+    expect(index.query([a], filters()).distinctValues.source["1.1.1"].crossFilteredCount).toBe(1);
+
+    index.update([], [telegram("missing", "0.0.0", "0/0/0", "Incoming", "x", null)]);
+    index.update([], [a]);
+    index.update([d], []);
+
+    expect((index as any)._nextIndex).toBe(1);
+    const result = index.query([d], filters());
+    expect(result.distinctValues.source["1.1.1"]).toBeUndefined();
+    expect(result.distinctValues.source["1.1.3"].crossFilteredCount).toBe(1);
+  });
+
+  it("clears every indexed value", () => {
+    const index = new FacetIndex();
+    index.update([a, b], []);
+    index.clear();
+
+    expect(index.query([], filters())).toEqual({
+      matchingTelegrams: [],
+      distinctValues: { source: {}, destination: {}, direction: {}, telegramtype: {}, dpt: {} },
+    });
+  });
+
+  it("preserves labels for selected values with zero counts", () => {
+    const index = new FacetIndex();
+    index.update([a], []);
+
+    const activeFilters = filters({ source: ["1.1.1"], destination: ["1/1/1"] });
+    index.clear(activeFilters);
+
+    const result = index.query([], activeFilters);
+    expect(result.distinctValues.source["1.1.1"]).toEqual({
+      id: "1.1.1",
+      name: "Source 1.1.1",
+      crossFilteredCount: 0,
+    });
+    expect(result.distinctValues.destination["1/1/1"]).toEqual({
+      id: "1/1/1",
+      name: "Destination 1/1/1",
+      crossFilteredCount: 0,
+    });
+  });
+
+  it("drops cleared values once they are no longer selected", () => {
+    const index = new FacetIndex();
+    index.update([a], []);
+
+    index.clear(filters({ source: ["1.1.1"] }));
+
+    const result = index.query([], filters());
+
+    expect(result.distinctValues.source["1.1.1"]).toBeUndefined();
+  });
+
+  it("uses cloned _all bitset on full scope query", () => {
+    const index = new FacetIndex();
+    index.update([a, b, c], []);
+
+    const spyClone = vi.spyOn((index as any)._all, "clone");
+    const result = index.query([a, b, c], filters(), true);
+
+    expect(spyClone).toHaveBeenCalled();
+    expect(result.matchingTelegrams.map((r) => r.id)).toEqual(["a", "b", "c"]);
+    spyClone.mockRestore();
+
+    const spyCloneNotFull = vi.spyOn((index as any)._all, "clone");
+    index.query([a, b], filters(), true);
+    expect(spyCloneNotFull).not.toHaveBeenCalled();
+    spyCloneNotFull.mockRestore();
+  });
+});

--- a/src/features/group-monitor/services/facet-index.test.ts
+++ b/src/features/group-monitor/services/facet-index.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { FacetIndex, type FacetTelegram, type FilterMap, UNKNOWN_DPT_ID } from "./facet-index";
+import {
+  FacetIndex,
+  FILTER_FIELDS,
+  type FacetTelegram,
+  type FilterMap,
+  UNKNOWN_DPT_ID,
+} from "./facet-index";
 
 const telegram = (
   id: string,
@@ -95,6 +101,30 @@ describe("FacetIndex", () => {
     const result = index.query([d], filters());
     expect(result.distinctValues.source["1.1.1"]).toBeUndefined();
     expect(result.distinctValues.source["1.1.3"].crossFilteredCount).toBe(1);
+  });
+
+  it("enriches an existing facet value when a later telegram supplies its name", () => {
+    const index = new FacetIndex();
+    const unnamedSource = { ...a, id: "unnamed-source", sourceText: null };
+    const namedSource = { ...a, id: "named-source", sourceText: "Living room switch" };
+
+    index.update([unnamedSource, namedSource], []);
+
+    expect(
+      index.query([unnamedSource, namedSource], filters()).distinctValues.source["1.1.1"].name,
+    ).toBe("Living room switch");
+  });
+
+  it("rejects an unsupported filter field", () => {
+    const index = new FacetIndex();
+    const mutableFilterFields = FILTER_FIELDS as unknown as string[];
+    mutableFilterFields.push("unsupported");
+
+    try {
+      expect(() => index.update([a], [])).toThrow("Unknown filter field: unsupported");
+    } finally {
+      mutableFilterFields.pop();
+    }
   });
 
   it("clears every indexed value", () => {

--- a/src/features/group-monitor/services/facet-index.ts
+++ b/src/features/group-monitor/services/facet-index.ts
@@ -122,8 +122,11 @@ export class FacetIndex {
    * immediately when a row is added in the same update.
    */
   public update(added: readonly FacetTelegram[], removed: readonly FacetTelegram[]): void {
+    const removedRows = new Set(removed);
     for (const telegram of removed) this._remove(telegram);
-    for (const telegram of added) this._add(telegram);
+    for (const telegram of added) {
+      if (!removedRows.has(telegram)) this._add(telegram);
+    }
   }
 
   /**

--- a/src/features/group-monitor/services/facet-index.ts
+++ b/src/features/group-monitor/services/facet-index.ts
@@ -1,0 +1,279 @@
+/**
+ * KNX Group Monitor Facet Index
+ *
+ * Maintains inverted bitset indexes for each filterable telegram property.
+ * This allows the Group Monitor to calculate matching telegrams and counts
+ * for every filter option without rescanning the complete buffer per facet.
+ */
+
+import { SparseTypedFastBitSet } from "typedfastbitset";
+
+/** Filterable telegram property represented by a Group Monitor facet. */
+export type FilterField = "source" | "destination" | "direction" | "telegramtype" | "dpt";
+
+/** All facets that participate in matching and cross-filter count calculations. */
+export const FILTER_FIELDS: readonly FilterField[] = [
+  "source",
+  "destination",
+  "direction",
+  "telegramtype",
+  "dpt",
+];
+
+/** Stable filter value representing telegrams without a known DPT. */
+export const UNKNOWN_DPT_ID = "unknown";
+
+/** Selected filter values, grouped by their facet. */
+export type FilterMap = Record<FilterField, ReadonlySet<string>>;
+
+/** Telegram fields required to build and query the facet indexes. */
+export interface FacetTelegram {
+  id: string;
+  sourceAddress: string;
+  sourceText: string | null;
+  destinationAddress: string;
+  destinationText: string | null;
+  direction: string;
+  type: string;
+  dptId: string | null;
+  dpt: string | null;
+}
+
+/** A single filter option and the number of telegrams it would match. */
+export interface DistinctValueInfo {
+  id: string;
+  name: string;
+  /** Matches after applying every active filter except this option's own facet. */
+  crossFilteredCount: number;
+}
+
+/** Available filter options, grouped by their facet. */
+export type DistinctValues = Record<FilterField, Record<string, DistinctValueInfo>>;
+
+/** Synchronized result of filtering telegrams and deriving all facet counts. */
+export interface FacetQueryResult<T extends FacetTelegram> {
+  matchingTelegrams: T[];
+  distinctValues: DistinctValues;
+}
+
+/** Inverted index entry for one value in a filter facet. */
+interface FacetEntry {
+  bits: SparseTypedFastBitSet;
+  name: string;
+}
+
+/** Creates a complete, empty result shape so every facet is always present. */
+const emptyDistinctValues = (): DistinctValues => ({
+  source: {},
+  destination: {},
+  direction: {},
+  telegramtype: {},
+  dpt: {},
+});
+
+/** Maps a telegram field to its stable filter value and display name. */
+const facetValue = (telegram: FacetTelegram, field: FilterField): { id: string; name: string } => {
+  switch (field) {
+    case "source":
+      return { id: telegram.sourceAddress, name: telegram.sourceText ?? "" };
+    case "destination":
+      return { id: telegram.destinationAddress, name: telegram.destinationText ?? "" };
+    case "direction":
+      return { id: telegram.direction, name: "" };
+    case "telegramtype":
+      return { id: telegram.type, name: "" };
+    case "dpt":
+      return telegram.dptId
+        ? { id: telegram.dptId, name: telegram.dpt ?? telegram.dptId }
+        : { id: UNKNOWN_DPT_ID, name: "" };
+  }
+  throw new Error(`Unknown filter field: ${field}`);
+};
+
+/**
+ * Bitset-backed inverted index for Group Monitor filters.
+ *
+ * Each indexed telegram has one numeric bit position. Every facet value keeps
+ * a bitset of its matching positions, allowing filter intersections and
+ * cross-filter counts to be calculated efficiently.
+ */
+export class FacetIndex {
+  /** Per-facet values and the bitsets of telegrams assigned to each value. */
+  private readonly _entries = new Map<FilterField, Map<string, FacetEntry>>(
+    FILTER_FIELDS.map((field) => [field, new Map<string, FacetEntry>()] as const),
+  );
+
+  /** Maps a telegram ID to its reusable bitset position. */
+  private readonly _idToIndex = new Map<string, number>();
+
+  /** Bitset containing every telegram currently tracked by this index. */
+  private _all = new SparseTypedFastBitSet();
+
+  /** Next unused bitset position when no removed position can be reused. */
+  private _nextIndex = 0;
+
+  /** Removed bitset positions available for a future telegram. */
+  private _freeIndices: number[] = [];
+
+  /**
+   * Applies buffer changes to the index.
+   *
+   * Removed rows are processed first so a freed bitset position can be reused
+   * immediately when a row is added in the same update.
+   */
+  public update(added: readonly FacetTelegram[], removed: readonly FacetTelegram[]): void {
+    for (const telegram of removed) this._remove(telegram);
+    for (const telegram of added) this._add(telegram);
+  }
+
+  /**
+   * Clears all indexed rows while retaining selected values as empty options.
+   *
+   * Retaining selections keeps active filter chips visible after the telegram
+   * buffer is cleared, even though their current match count is zero.
+   */
+  public clear(filters?: FilterMap): void {
+    const preservedEntries = new Map<FilterField, Map<string, string>>();
+    if (filters) {
+      for (const field of FILTER_FIELDS) {
+        const entries = new Map<string, string>();
+        for (const id of filters[field]) {
+          const entry = this._entries.get(field)!.get(id);
+          if (entry) entries.set(id, entry.name);
+        }
+        preservedEntries.set(field, entries);
+      }
+    }
+
+    for (const entries of this._entries.values()) entries.clear();
+    this._idToIndex.clear();
+    this._all = new SparseTypedFastBitSet();
+    this._nextIndex = 0;
+    this._freeIndices = [];
+
+    for (const [field, entries] of preservedEntries) {
+      const values = this._entries.get(field)!;
+      for (const [id, name] of entries) {
+        values.set(id, { bits: new SparseTypedFastBitSet(), name });
+      }
+    }
+  }
+
+  /**
+   * Filters telegrams in a scope and calculates the options for every facet.
+   *
+   * A facet's `crossFilteredCount` applies active filters from every other
+   * facet, but excludes the facet itself. This lets users see which values can
+   * be selected next without hiding alternatives in the currently open facet.
+   *
+   * @param scope - Telegrams eligible for this query after time-range filtering.
+   * @param filters - Currently selected values for every facet.
+   * @param isFullScope - Whether `scope` contains every currently indexed row.
+   * @returns Matching telegrams and per-facet cross-filter counts.
+   */
+  public query<T extends FacetTelegram>(
+    scope: readonly T[],
+    filters: FilterMap,
+    isFullScope?: boolean,
+  ): FacetQueryResult<T> {
+    const scopeBits = this._scopeBits(scope, isFullScope);
+    const activeMasks = new Map<FilterField, SparseTypedFastBitSet>();
+
+    for (const field of FILTER_FIELDS) {
+      if (filters[field].size === 0) continue;
+      const union = new SparseTypedFastBitSet();
+      for (const value of filters[field]) {
+        const entry = this._entries.get(field)!.get(value);
+        if (entry) union.union(entry.bits);
+      }
+      activeMasks.set(field, union);
+    }
+
+    const matchingBits = scopeBits.clone();
+    for (const mask of activeMasks.values()) matchingBits.intersection(mask);
+
+    const matchingTelegrams = scope.filter((telegram) => {
+      const index = this._idToIndex.get(telegram.id);
+      return index !== undefined && matchingBits.has(index);
+    });
+
+    const distinctValues = emptyDistinctValues();
+    for (const field of FILTER_FIELDS) {
+      const crossBits = scopeBits.clone();
+      for (const [activeField, mask] of activeMasks) {
+        if (activeField !== field) crossBits.intersection(mask);
+      }
+
+      for (const [id, entry] of this._entries.get(field)!) {
+        if (entry.bits.isEmpty() && !filters[field].has(id)) continue;
+        distinctValues[field][id] = {
+          id,
+          name: entry.name,
+          crossFilteredCount: entry.bits.intersection_size(crossBits),
+        };
+      }
+
+      for (const id of filters[field]) {
+        distinctValues[field][id] ??= { id, name: "", crossFilteredCount: 0 };
+      }
+    }
+
+    return { matchingTelegrams, distinctValues };
+  }
+
+  /** Returns the index positions contained in a query scope. */
+  private _scopeBits(
+    scope: readonly FacetTelegram[],
+    isFullScope?: boolean,
+  ): SparseTypedFastBitSet {
+    if (isFullScope && scope.length === this._idToIndex.size) {
+      return this._all.clone();
+    }
+    const result = new SparseTypedFastBitSet();
+    for (const telegram of scope) {
+      const index = this._idToIndex.get(telegram.id);
+      if (index !== undefined) result.add(index);
+    }
+    return result;
+  }
+
+  /** Adds one telegram to every applicable facet index. */
+  private _add(telegram: FacetTelegram): void {
+    if (this._idToIndex.has(telegram.id)) return;
+    const index = this._freeIndices.pop() ?? this._nextIndex++;
+    this._idToIndex.set(telegram.id, index);
+    this._all.add(index);
+
+    for (const field of FILTER_FIELDS) {
+      const { id, name } = facetValue(telegram, field);
+      const values = this._entries.get(field)!;
+      let entry = values.get(id);
+      if (!entry) {
+        entry = { bits: new SparseTypedFastBitSet(), name };
+        values.set(id, entry);
+      } else if (!entry.name && name) {
+        entry.name = name;
+      }
+      entry.bits.add(index);
+    }
+  }
+
+  /** Removes one telegram from every applicable facet index. */
+  private _remove(telegram: FacetTelegram): void {
+    const index = this._idToIndex.get(telegram.id);
+    if (index === undefined) return;
+
+    for (const field of FILTER_FIELDS) {
+      const { id } = facetValue(telegram, field);
+      const values = this._entries.get(field)!;
+      const entry = values.get(id);
+      if (!entry) continue;
+      entry.bits.remove(index);
+      if (entry.bits.isEmpty()) values.delete(id);
+    }
+
+    this._idToIndex.delete(telegram.id);
+    this._all.remove(index);
+    this._freeIndices.push(index);
+  }
+}

--- a/src/features/group-monitor/services/telegram-buffer-service.test.ts
+++ b/src/features/group-monitor/services/telegram-buffer-service.test.ts
@@ -351,6 +351,15 @@ describe("TelegramBufferService", () => {
       expect(service.snapshot).not.toBe(afterTrim);
       expect(service.snapshot).toEqual([]);
     });
+
+    it("prevents runtime mutations of a cached snapshot", () => {
+      const snapshot = service.snapshot;
+      const mutableSnapshot = snapshot as TelegramRow[];
+
+      expect(() => mutableSnapshot.pop()).toThrow(TypeError);
+      expect(service.snapshot).toBe(snapshot);
+      expect(service.snapshot).toEqual(telegrams);
+    });
   });
 
   describe("Edge Cases", () => {

--- a/src/features/group-monitor/services/telegram-buffer-service.test.ts
+++ b/src/features/group-monitor/services/telegram-buffer-service.test.ts
@@ -183,6 +183,28 @@ describe("TelegramBufferService", () => {
       expect(service.snapshot).toEqual([withOffset]);
     });
 
+    it.each(["add", "merge"] as const)(
+      "should deduplicate %s batches before sorting and eviction",
+      (method) => {
+        service = new TelegramBufferService(2);
+        const [oldest, middle, newest] = createTelegrams(3);
+        const duplicate = createTelegramRow(middle.timestampIso, "1");
+
+        const result = service[method]([newest, middle, duplicate, oldest, newest]);
+
+        expect(result).toEqual(
+          method === "add" ? [oldest] : { added: [oldest, middle, newest], removed: [oldest] },
+        );
+        expect(service.snapshot).toEqual([middle, newest]);
+        expect(service.snapshot[0]).toBe(middle);
+        const snapshot = service.snapshot;
+        expect(service[method]([duplicate, newest])).toEqual(
+          method === "add" ? [] : { added: [], removed: [] },
+        );
+        expect(service.snapshot).toBe(snapshot);
+      },
+    );
+
     it("should merge unique telegrams", () => {
       const telegram1 = createTelegramRow("2024-01-01T10:00:01.000Z", "1");
       const telegram2 = createTelegramRow("2024-01-01T10:00:03.000Z", "3");
@@ -223,6 +245,38 @@ describe("TelegramBufferService", () => {
       expect(result.added.length).toBe(1);
       expect(result.added[0].timestampIso).toBe("2024-01-01T10:00:03.000Z");
       expect(service.length).toBe(3);
+    });
+
+    it("maintains existingIds cache across merge, eviction, setMaxSize, and clear", () => {
+      service = new TelegramBufferService(3);
+      const [t1, t2, t3, t4] = createTelegrams(4);
+
+      // Add 3 telegrams
+      service.merge([t1, t2, t3]);
+      expect((service as any)._existingIds.has(t1.id)).toBe(true);
+      expect((service as any)._existingIds.size).toBe(3);
+
+      // Adding duplicate should return empty added without scanning/altering
+      const duplicateRes = service.merge([t1]);
+      expect(duplicateRes.added).toEqual([]);
+
+      // Adding 4th overflows t1
+      const overflowRes = service.merge([t4]);
+      expect(overflowRes.added).toEqual([t4]);
+      expect(overflowRes.removed).toEqual([t1]);
+      expect((service as any)._existingIds.has(t1.id)).toBe(false);
+      expect((service as any)._existingIds.has(t4.id)).toBe(true);
+      expect((service as any)._existingIds.size).toBe(3);
+
+      // setMaxSize eviction
+      const evicted = service.setMaxSize(2);
+      expect(evicted).toEqual([t2]);
+      expect((service as any)._existingIds.has(t2.id)).toBe(false);
+      expect((service as any)._existingIds.size).toBe(2);
+
+      // clear
+      service.clear();
+      expect((service as any)._existingIds.size).toBe(0);
     });
   });
 
@@ -277,6 +331,26 @@ describe("TelegramBufferService", () => {
       expect(service.getById(telegrams[0].id)).toBe(telegrams[0]);
       expect(service.getById("non-existent")).toBeUndefined();
     });
+
+    it("should reuse its immutable snapshot until the buffer changes", () => {
+      const first = service.snapshot;
+
+      expect(service.snapshot).toBe(first);
+
+      service.add(createTelegramRow("2024-01-01T10:00:03.000Z", "3"));
+      const afterAdd = service.snapshot;
+      expect(afterAdd).not.toBe(first);
+      expect(service.snapshot).toBe(afterAdd);
+
+      service.setMaxSize(2);
+      const afterTrim = service.snapshot;
+      expect(afterTrim).not.toBe(afterAdd);
+      expect(service.snapshot).toBe(afterTrim);
+
+      service.clear();
+      expect(service.snapshot).not.toBe(afterTrim);
+      expect(service.snapshot).toEqual([]);
+    });
   });
 
   describe("Edge Cases", () => {
@@ -305,7 +379,7 @@ describe("TelegramBufferService", () => {
       const snapshot1 = service.snapshot;
       const snapshot2 = service.snapshot;
 
-      expect(snapshot1).not.toBe(snapshot2); // Different instances
+      expect(snapshot1).toBe(snapshot2); // Reused until the buffer changes
       expect(snapshot1).toEqual(snapshot2); // Same content
     });
   });

--- a/src/features/group-monitor/services/telegram-buffer-service.ts
+++ b/src/features/group-monitor/services/telegram-buffer-service.ts
@@ -136,7 +136,7 @@ export class TelegramBufferService {
    * Safe for external use without risk of modification
    */
   get snapshot(): readonly TelegramRow[] {
-    if (this._snapshot === undefined) this._snapshot = [...this._buffer];
+    if (this._snapshot === undefined) this._snapshot = Object.freeze([...this._buffer]);
     return this._snapshot;
   }
 

--- a/src/features/group-monitor/services/telegram-buffer-service.ts
+++ b/src/features/group-monitor/services/telegram-buffer-service.ts
@@ -11,28 +11,52 @@ import type { TelegramRow } from "../types/telegram-row";
  */
 export class TelegramBufferService {
   private _buffer: TelegramRow[] = [];
+  private _snapshot?: readonly TelegramRow[];
+  private _existingIds = new Set<string>();
+
+  private _invalidateSnapshot(): void {
+    this._snapshot = undefined;
+  }
 
   constructor(private _maxSize = 2000) {}
 
   /**
-   * Adds one or more telegrams to the buffer
+   * Adds one or more telegrams to the buffer, avoiding duplicate IDs
    * Telegrams are inserted in chronological order based on their timestamp (microsecond precision)
    * Only sorts if necessary for optimal performance
    * @param telegrams - Single telegram or array of telegrams to add
    * @returns Array of telegrams that were removed due to buffer overflow (empty if no overflow)
    */
   add(telegrams: TelegramRow | TelegramRow[]): TelegramRow[] {
-    const telegramArray = Array.isArray(telegrams) ? telegrams : [telegrams];
+    return this.merge(Array.isArray(telegrams) ? telegrams : [telegrams]).removed;
+  }
 
-    // Quick check: if buffer is empty, add and sort if necessary
+  /**
+   * Adds multiple telegrams, avoiding duplicates.
+   *
+   * The separate added and removed collections let dependent indexes stay in
+   * sync without rescanning the buffer after a merge or an overflow.
+   *
+   * @param newTelegrams - Array of telegrams to merge
+   * @returns Unique rows added and rows removed because the buffer overflowed.
+   */
+  merge(newTelegrams: TelegramRow[]): { added: TelegramRow[]; removed: TelegramRow[] } {
+    if (newTelegrams.length === 0) return { added: [], removed: [] };
+
+    const telegramArray = newTelegrams.filter((telegram) => {
+      if (this._existingIds.has(telegram.id)) return false;
+      this._existingIds.add(telegram.id);
+      return true;
+    });
+    if (telegramArray.length === 0) return { added: [], removed: [] };
+
+    telegramArray.sort((a, b) =>
+      a.timestampIso < b.timestampIso ? -1 : a.timestampIso > b.timestampIso ? 1 : 0,
+    );
+
+    // Quick check: if buffer is empty, add directly (already sorted above)
     if (this._buffer.length === 0) {
       this._buffer.push(...telegramArray);
-      // Sort if we have multiple telegrams that might be unsorted
-      if (telegramArray.length > 1) {
-        this._buffer.sort((a, b) =>
-          a.timestampIso < b.timestampIso ? -1 : a.timestampIso > b.timestampIso ? 1 : 0,
-        );
-      }
     } else {
       const lastTimestamp = this._buffer[this._buffer.length - 1].timestampIso;
 
@@ -60,40 +84,15 @@ export class TelegramBufferService {
     if (this._buffer.length > this._maxSize) {
       const excessCount = this._buffer.length - this._maxSize;
       const removedTelegrams = this._buffer.splice(0, excessCount);
-      return removedTelegrams;
+      for (const removed of removedTelegrams) {
+        this._existingIds.delete(removed.id);
+      }
+      this._invalidateSnapshot();
+      return { added: telegramArray, removed: removedTelegrams };
     }
 
-    return [];
-  }
-
-  /**
-   * Adds multiple telegrams, avoiding duplicates
-   * @param newTelegrams - Array of telegrams to merge
-   * @returns Object containing unique new telegrams added and removed telegrams due to overflow
-   */
-  merge(newTelegrams: TelegramRow[]): { added: TelegramRow[]; removed: TelegramRow[] } {
-    // Create a Set of existing telegram IDs for efficient lookup
-    const existingIds = new Set(this._buffer.map((t) => t.id));
-
-    // Filter out duplicates from new telegrams
-    const uniqueNewTelegrams = newTelegrams.filter((telegram) => {
-      if (existingIds.has(telegram.id)) return false;
-      existingIds.add(telegram.id);
-      return true;
-    });
-
-    // Sort new telegrams by timestamp to maintain chronological order
-    uniqueNewTelegrams.sort((a, b) =>
-      a.timestampIso < b.timestampIso ? -1 : a.timestampIso > b.timestampIso ? 1 : 0,
-    );
-
-    // Add new telegrams and get removed telegrams
-    const removedTelegrams = this.add(uniqueNewTelegrams);
-
-    return {
-      added: uniqueNewTelegrams,
-      removed: removedTelegrams,
-    };
+    this._invalidateSnapshot();
+    return { added: telegramArray, removed: [] };
   }
 
   /**
@@ -108,6 +107,10 @@ export class TelegramBufferService {
     if (this._buffer.length > size) {
       const excessCount = this._buffer.length - size;
       const removedTelegrams = this._buffer.splice(0, excessCount);
+      for (const removed of removedTelegrams) {
+        this._existingIds.delete(removed.id);
+      }
+      this._invalidateSnapshot();
       return removedTelegrams;
     }
 
@@ -133,7 +136,8 @@ export class TelegramBufferService {
    * Safe for external use without risk of modification
    */
   get snapshot(): readonly TelegramRow[] {
-    return [...this._buffer];
+    if (this._snapshot === undefined) this._snapshot = [...this._buffer];
+    return this._snapshot;
   }
 
   /**
@@ -141,8 +145,11 @@ export class TelegramBufferService {
    * @returns Array of all telegrams that were cleared
    */
   clear(): TelegramRow[] {
+    if (this._buffer.length === 0) return [];
     const clearedTelegrams = [...this._buffer];
     this._buffer.length = 0;
+    this._existingIds.clear();
+    this._invalidateSnapshot();
     return clearedTelegrams;
   }
 

--- a/src/features/group-monitor/views/group-monitor-view.test.ts
+++ b/src/features/group-monitor/views/group-monitor-view.test.ts
@@ -119,6 +119,27 @@ describe("KNXGroupMonitor", () => {
     expect(mockController.clearTelegrams).toHaveBeenCalled();
   });
 
+  it("merges DPT metadata with cross-filter counts", () => {
+    element.knx = {
+      dptMetadata: { "1.001": { name: "Switch" }, "5.001": { name: "Percent" } },
+    } as any;
+
+    const data = (element as any)._getDptFilterData({
+      source: {},
+      destination: {},
+      direction: {},
+      telegramtype: {},
+      dpt: {
+        "1.001": { id: "1.001", name: "", crossFilteredCount: 3 },
+        unknown: { id: "unknown", name: "", crossFilteredCount: 2 },
+      },
+    });
+
+    expect(data).toContainEqual({ id: "1.001", name: "Switch", crossFilteredCount: 3 });
+    expect(data).toContainEqual({ id: "5.001", name: "Percent", crossFilteredCount: 0 });
+    expect(data).toContainEqual({ id: "unknown", name: "", crossFilteredCount: 2 });
+  });
+
   describe("migrateStoredColumns", () => {
     it("inserts the offset column right after timestampIso for both layouts", () => {
       const migrated = migrateStoredColumns({

--- a/src/features/group-monitor/views/group-monitor-view.test.ts
+++ b/src/features/group-monitor/views/group-monitor-view.test.ts
@@ -140,6 +140,37 @@ describe("KNXGroupMonitor", () => {
     expect(data).toContainEqual({ id: "unknown", name: "", crossFilteredCount: 2 });
   });
 
+  it("uses a telegram-provided DPT name when it has no metadata", () => {
+    element.knx = { dptMetadata: {} } as any;
+
+    const data = (element as any)._getDptFilterData({
+      source: {},
+      destination: {},
+      direction: {},
+      telegramtype: {},
+      dpt: {
+        "7.001": { id: "7.001", name: "DPT 7.001", crossFilteredCount: 1 },
+      },
+    });
+
+    expect(data).toContainEqual({ id: "7.001", name: "DPT 7.001", crossFilteredCount: 1 });
+  });
+
+  it("uses cross-filter counts in every filter badge", () => {
+    const item = { id: "1.1.1", name: "Switch", crossFilteredCount: 4 };
+    const filterConfigs = [
+      (element as any)._sourceFilterConfig("en"),
+      (element as any)._destinationFilterConfig("en"),
+      (element as any)._directionFilterConfig("en"),
+      (element as any)._telegramTypeFilterConfig("en"),
+      (element as any)._dptFilterConfig("en"),
+    ];
+
+    for (const config of filterConfigs) {
+      expect(config.badgeField.mapper(item)).toBe("4");
+    }
+  });
+
   describe("migrateStoredColumns", () => {
     it("inserts the offset column right after timestampIso for both layouts", () => {
       const migrated = migrateStoredColumns({

--- a/src/features/group-monitor/views/group-monitor-view.ts
+++ b/src/features/group-monitor/views/group-monitor-view.ts
@@ -27,7 +27,7 @@ import "../../../components/data-table/filter/knx-list-filter";
 import "../../../components/data-table/filter/knx-time-delta-filter";
 import "../../../components/data-table/filter/knx-time-range-filter";
 
-import { customElement, property, query, state } from "lit/decorators";
+import { customElement, property, state } from "lit/decorators";
 import { storage } from "@ha/common/decorators/storage";
 import {
   mdiClose,
@@ -43,12 +43,13 @@ import type { TelegramInfoDialogParams } from "../dialogs/telegram-info-dialog";
 import { formatTimeWithMilliseconds, formatTimeDelta, formatDate } from "../../../utils/format";
 import type { TelegramRow, TelegramRowKeys } from "../types/telegram-row";
 import type { ToggleFilterEvent } from "../../../components/data-table/cell/knx-table-cell-filterable";
-import { GroupMonitorController, UNKNOWN_DPT_ID } from "../controller/group-monitor-controller";
-import type {
-  DistinctValueInfo,
-  DistinctValues,
-  HistoryWarning,
-} from "../controller/group-monitor-controller";
+import { GroupMonitorController } from "../controller/group-monitor-controller";
+import type { HistoryWarning } from "../controller/group-monitor-controller";
+import {
+  UNKNOWN_DPT_ID,
+  type DistinctValueInfo,
+  type DistinctValues,
+} from "../services/facet-index";
 import { groupMonitorTab } from "../../../knx-router";
 
 import type { KNX } from "../../../types/knx";
@@ -56,7 +57,6 @@ import type {
   SelectionChangedEvent as ListFilterSelectionChangedEvent,
   ExpandedChangedEvent as ListFilterExpandedChangedEvent,
   Config as ListFilterConfig,
-  KnxListFilter,
 } from "../../../components/data-table/filter/knx-list-filter";
 import type { TimeDeltaChangedEvent } from "../../../components/data-table/filter/knx-time-delta-filter";
 import type { TimeRangeChangedEvent } from "../../../components/data-table/filter/knx-time-range-filter";
@@ -205,15 +205,6 @@ export class KNXGroupMonitor extends LitElement {
   /** GroupMonitor controller instance */
   private controller = new GroupMonitorController(this);
 
-  /** Reference to source filter component */
-  @query('knx-list-filter[data-filter="source"]') private sourceFilter?: KnxListFilter;
-
-  /** Reference to destination filter component */
-  @query('knx-list-filter[data-filter="destination"]') private destinationFilter?: KnxListFilter;
-
-  /** Reference to dpt filter component */
-  @query('knx-list-filter[data-filter="dpt"]') private dptFilter?: KnxListFilter;
-
   /**
    * Detects if the current device is a mobile touch device
    * Used to disable quick filter buttons on mobile for better UX
@@ -223,14 +214,19 @@ export class KNXGroupMonitor extends LitElement {
   }
 
   /**
-   * Gets both filtered telegrams and distinct values in a single call to avoid update loops
+   * Gets both filtered telegrams and cross-filtered facet values in one call.
+   * Keeping them synchronized prevents the table and filter badges from
+   * rendering against different filter states.
    */
   private _getFilteredData() {
     return this.controller.getFilteredTelegramsAndDistinctValues();
   }
 
   /**
-   * Combines all available DPTs from metadata with dynamic counts from telegrams
+   * Combines known DPT metadata with telegram-derived cross-filter counts.
+   *
+   * Metadata-only DPTs and the unknown bucket remain selectable even when no
+   * telegram currently matches them.
    */
   private _getDptFilterData(distinctValues: DistinctValues): DistinctValueInfo[] {
     const dptMap: Record<string, DistinctValueInfo> = {};
@@ -241,8 +237,7 @@ export class KNXGroupMonitor extends LitElement {
         dptMap[dptId] = {
           id: dptId,
           name: meta.name || "",
-          totalCount: 0,
-          filteredCount: 0,
+          crossFilteredCount: 0,
         };
       }
     }
@@ -251,24 +246,17 @@ export class KNXGroupMonitor extends LitElement {
     dptMap[UNKNOWN_DPT_ID] = {
       id: UNKNOWN_DPT_ID,
       name: "",
-      totalCount: 0,
-      filteredCount: 0,
+      crossFilteredCount: 0,
     };
 
     // 3. Override/update with actual telegram distinct values
     for (const info of Object.values(distinctValues.dpt)) {
       const dptId = info.id;
-      if (dptMap[dptId]) {
-        dptMap[dptId].totalCount = info.totalCount;
-        dptMap[dptId].filteredCount = info.filteredCount;
-      } else {
-        dptMap[dptId] = {
-          id: info.id,
-          name: info.name,
-          totalCount: info.totalCount,
-          filteredCount: info.filteredCount,
-        };
-      }
+      dptMap[dptId] = {
+        ...dptMap[dptId],
+        ...info,
+        name: dptMap[dptId]?.name || info.name,
+      };
     }
 
     return Object.values(dptMap);
@@ -309,28 +297,10 @@ export class KNXGroupMonitor extends LitElement {
   // ============================================================================
 
   /**
-   * Checks if any filters are currently active
-   * @param filterField - Optional specific filter field to check (e.g., 'source', 'destination', 'direction', 'telegramtype')
-   * @returns True if filters are active (either any filter or the specified filter field)
-   */
-  private _hasActiveFilters(filterField?: string): boolean {
-    if (filterField) {
-      const filter = this.controller.filters[filterField];
-      return Array.isArray(filter) && filter.length > 0;
-    }
-    return Object.values(this.controller.filters).some((f) => Array.isArray(f) && f.length > 0);
-  }
-
-  /**
    * Memoized configuration for source address filter
    */
   private _sourceFilterConfig = memoize(
-    (
-      hasActiveFilters: boolean,
-      sourceFiltersLength: number,
-      sourceFilterSortCriterion: string | undefined,
-      _language: string,
-    ): ListFilterConfig<DistinctValueInfo> => ({
+    (_language: string): ListFilterConfig<DistinctValueInfo> => ({
       idField: {
         filterable: false,
         sortable: false,
@@ -357,30 +327,9 @@ export class KNXGroupMonitor extends LitElement {
       badgeField: {
         fieldName: this.knx.localize("telegram_filter_source_sort_by_badge"),
         filterable: false,
-        sortable: false,
-        mapper: (item: DistinctValueInfo) =>
-          hasActiveFilters ? `${item.filteredCount}/${item.totalCount}` : `${item.totalCount}`,
-      },
-      custom: {
-        totalCount: {
-          fieldName: this.knx.localize("telegram_filter_sort_by_total_count"),
-          filterable: false,
-          sortable: true,
-          sortAscendingText: this.knx.localize("telegram_filter_sort_ascending"),
-          sortDescendingText: this.knx.localize("telegram_filter_sort_descending"),
-          sortDefaultDirection: "desc",
-          mapper: (item: DistinctValueInfo) => item.totalCount.toString(),
-        },
-        filteredCount: {
-          fieldName: this.knx.localize("telegram_filter_sort_by_filtered_count"),
-          filterable: false,
-          sortable: sourceFiltersLength > 0 || sourceFilterSortCriterion === "filteredCount",
-          sortDisabled: sourceFiltersLength === 0,
-          sortAscendingText: this.knx.localize("telegram_filter_sort_ascending"),
-          sortDescendingText: this.knx.localize("telegram_filter_sort_descending"),
-          sortDefaultDirection: "desc",
-          mapper: (item: DistinctValueInfo) => (item.filteredCount || 0).toString(),
-        },
+        sortable: true,
+        sortDefaultDirection: "desc",
+        mapper: (item: DistinctValueInfo) => `${item.crossFilteredCount}`,
       },
     }),
   );
@@ -389,12 +338,7 @@ export class KNXGroupMonitor extends LitElement {
    * Memoized configuration for destination address filter
    */
   private _destinationFilterConfig = memoize(
-    (
-      hasActiveFilters: boolean,
-      destinationFiltersLength: number,
-      destinationFilterSortCriterion: string | undefined,
-      _language: string,
-    ): ListFilterConfig<DistinctValueInfo> => ({
+    (_language: string): ListFilterConfig<DistinctValueInfo> => ({
       idField: {
         filterable: false,
         sortable: false,
@@ -421,32 +365,9 @@ export class KNXGroupMonitor extends LitElement {
       badgeField: {
         fieldName: this.knx.localize("telegram_filter_destination_sort_by_badge"),
         filterable: false,
-        sortable: false,
-        mapper: (item: DistinctValueInfo) =>
-          hasActiveFilters ? `${item.filteredCount}/${item.totalCount}` : `${item.totalCount}`,
-      },
-      custom: {
-        totalCount: {
-          fieldName: this.knx.localize("telegram_filter_sort_by_total_count"),
-          filterable: false,
-          sortable: true,
-          sortAscendingText: this.knx.localize("telegram_filter_sort_ascending"),
-          sortDescendingText: this.knx.localize("telegram_filter_sort_descending"),
-          sortDefaultDirection: "desc",
-          mapper: (item: DistinctValueInfo) => item.totalCount.toString(),
-          // Removed custom comparator - using new unified lazy system
-        },
-        filteredCount: {
-          fieldName: this.knx.localize("telegram_filter_sort_by_filtered_count"),
-          filterable: false,
-          sortable:
-            destinationFiltersLength > 0 || destinationFilterSortCriterion === "filteredCount",
-          sortDisabled: destinationFiltersLength === 0,
-          sortAscendingText: this.knx.localize("telegram_filter_sort_ascending"),
-          sortDescendingText: this.knx.localize("telegram_filter_sort_descending"),
-          sortDefaultDirection: "desc",
-          mapper: (item: DistinctValueInfo) => (item.filteredCount || 0).toString(),
-        },
+        sortable: true,
+        sortDefaultDirection: "desc",
+        mapper: (item: DistinctValueInfo) => `${item.crossFilteredCount}`,
       },
     }),
   );
@@ -455,7 +376,7 @@ export class KNXGroupMonitor extends LitElement {
    * Memoized configuration for direction filter (Incoming/Outgoing)
    */
   private _directionFilterConfig = memoize(
-    (hasActiveFilters: boolean, _language: string): ListFilterConfig<DistinctValueInfo> => ({
+    (_language: string): ListFilterConfig<DistinctValueInfo> => ({
       idField: {
         filterable: false,
         sortable: false,
@@ -474,8 +395,7 @@ export class KNXGroupMonitor extends LitElement {
       badgeField: {
         filterable: false,
         sortable: false,
-        mapper: (item: DistinctValueInfo) =>
-          hasActiveFilters ? `${item.filteredCount}/${item.totalCount}` : `${item.totalCount}`,
+        mapper: (item: DistinctValueInfo) => `${item.crossFilteredCount}`,
       },
     }),
   );
@@ -484,7 +404,7 @@ export class KNXGroupMonitor extends LitElement {
    * Memoized configuration for telegram type filter
    */
   private _telegramTypeFilterConfig = memoize(
-    (hasActiveFilters: boolean, _language: string): ListFilterConfig<DistinctValueInfo> => ({
+    (_language: string): ListFilterConfig<DistinctValueInfo> => ({
       idField: {
         filterable: false,
         sortable: false,
@@ -503,8 +423,7 @@ export class KNXGroupMonitor extends LitElement {
       badgeField: {
         filterable: false,
         sortable: false,
-        mapper: (item: DistinctValueInfo) =>
-          hasActiveFilters ? `${item.filteredCount}/${item.totalCount}` : `${item.totalCount}`,
+        mapper: (item: DistinctValueInfo) => `${item.crossFilteredCount}`,
       },
     }),
   );
@@ -512,46 +431,39 @@ export class KNXGroupMonitor extends LitElement {
   /**
    * Memoized configuration for DPT filter
    */
-  private _dptFilterConfig = memoize(
-    (
-      hasActiveFilters: boolean,
-      _dptFiltersLength: number,
-      _dptFilterSortCriterion: string | undefined,
-      _language: string,
-    ): ListFilterConfig<DistinctValueInfo> => ({
-      idField: {
-        filterable: false,
-        sortable: false,
-        mapper: (item: DistinctValueInfo) => item.id,
-      },
-      primaryField: {
-        fieldName: this.knx.localize("telegram_filter_dpt_sort_by_primaryText"),
-        filterable: true,
-        sortable: true,
-        sortAscendingText: this.knx.localize("telegram_filter_sort_ascending"),
-        sortDescendingText: this.knx.localize("telegram_filter_sort_descending"),
-        sortDefaultDirection: "asc",
-        mapper: (item: DistinctValueInfo) =>
-          item.id === UNKNOWN_DPT_ID ? this.hass.localize("state.default.unknown") : item.id,
-      },
-      secondaryField: {
-        fieldName: this.knx.localize("telegram_filter_dpt_sort_by_secondaryText"),
-        filterable: true,
-        sortable: true,
-        sortAscendingText: this.knx.localize("telegram_filter_sort_ascending"),
-        sortDescendingText: this.knx.localize("telegram_filter_sort_descending"),
-        sortDefaultDirection: "asc",
-        mapper: (item: DistinctValueInfo) => item.name,
-      },
-      badgeField: {
-        fieldName: this.knx.localize("telegram_filter_dpt_sort_by_badge"),
-        filterable: false,
-        sortable: false,
-        mapper: (item: DistinctValueInfo) =>
-          hasActiveFilters ? `${item.filteredCount}/${item.totalCount}` : `${item.totalCount}`,
-      },
-    }),
-  );
+  private _dptFilterConfig = memoize((_language: string): ListFilterConfig<DistinctValueInfo> => ({
+    idField: {
+      filterable: false,
+      sortable: false,
+      mapper: (item: DistinctValueInfo) => item.id,
+    },
+    primaryField: {
+      fieldName: this.knx.localize("telegram_filter_dpt_sort_by_primaryText"),
+      filterable: true,
+      sortable: true,
+      sortAscendingText: this.knx.localize("telegram_filter_sort_ascending"),
+      sortDescendingText: this.knx.localize("telegram_filter_sort_descending"),
+      sortDefaultDirection: "asc",
+      mapper: (item: DistinctValueInfo) =>
+        item.id === UNKNOWN_DPT_ID ? this.hass.localize("state.default.unknown") : item.id,
+    },
+    secondaryField: {
+      fieldName: this.knx.localize("telegram_filter_dpt_sort_by_secondaryText"),
+      filterable: true,
+      sortable: true,
+      sortAscendingText: this.knx.localize("telegram_filter_sort_ascending"),
+      sortDescendingText: this.knx.localize("telegram_filter_sort_descending"),
+      sortDefaultDirection: "asc",
+      mapper: (item: DistinctValueInfo) => item.name,
+    },
+    badgeField: {
+      fieldName: this.knx.localize("telegram_filter_dpt_sort_by_badge"),
+      filterable: false,
+      sortable: true,
+      sortDefaultDirection: "desc",
+      mapper: (item: DistinctValueInfo) => `${item.crossFilteredCount}`,
+    },
+  }));
 
   // ============================================================================
   // Event Handlers
@@ -1271,14 +1183,7 @@ export class KNXGroupMonitor extends LitElement {
           .hass=${this.hass}
           .knx=${this.knx}
           .data=${Object.values(distinctValues.source)}
-          .config=${
-            this._sourceFilterConfig(
-              this._hasActiveFilters("source"),
-              this.controller.filters.source?.length || 0,
-              this.sourceFilter?.sortCriterion,
-              this.hass.language,
-            ) as any
-          }
+          .config=${this._sourceFilterConfig(this.hass.language) as any}
           .selectedOptions=${this.controller.filters.source}
           .expanded=${this.controller.expandedFilter === "source"}
           .narrow=${this.narrow}
@@ -1296,14 +1201,7 @@ export class KNXGroupMonitor extends LitElement {
           .hass=${this.hass}
           .knx=${this.knx}
           .data=${Object.values(distinctValues.destination)}
-          .config=${
-            this._destinationFilterConfig(
-              this._hasActiveFilters("destination"),
-              this.controller.filters.destination?.length || 0,
-              this.destinationFilter?.sortCriterion,
-              this.hass.language,
-            ) as any
-          }
+          .config=${this._destinationFilterConfig(this.hass.language) as any}
           .selectedOptions=${this.controller.filters.destination}
           .expanded=${this.controller.expandedFilter === "destination"}
           .narrow=${this.narrow}
@@ -1320,12 +1218,7 @@ export class KNXGroupMonitor extends LitElement {
           .hass=${this.hass}
           .knx=${this.knx}
           .data=${Object.values(distinctValues.direction)}
-          .config=${
-            this._directionFilterConfig(
-              this._hasActiveFilters("direction"),
-              this.hass.language,
-            ) as any
-          }
+          .config=${this._directionFilterConfig(this.hass.language) as any}
           .selectedOptions=${this.controller.filters.direction}
           .pinSelectedItems=${false}
           .expanded=${this.controller.expandedFilter === "direction"}
@@ -1342,12 +1235,7 @@ export class KNXGroupMonitor extends LitElement {
           .hass=${this.hass}
           .knx=${this.knx}
           .data=${Object.values(distinctValues.telegramtype)}
-          .config=${
-            this._telegramTypeFilterConfig(
-              this._hasActiveFilters("telegramtype"),
-              this.hass.language,
-            ) as any
-          }
+          .config=${this._telegramTypeFilterConfig(this.hass.language) as any}
           .selectedOptions=${this.controller.filters.telegramtype}
           .pinSelectedItems=${false}
           .expanded=${this.controller.expandedFilter === "telegramtype"}
@@ -1365,14 +1253,7 @@ export class KNXGroupMonitor extends LitElement {
           .hass=${this.hass}
           .knx=${this.knx}
           .data=${this._getDptFilterData(distinctValues)}
-          .config=${
-            this._dptFilterConfig(
-              this._hasActiveFilters("dpt"),
-              this.controller.filters.dpt?.length || 0,
-              this.dptFilter?.sortCriterion,
-              this.hass.language,
-            ) as any
-          }
+          .config=${this._dptFilterConfig(this.hass.language) as any}
           .selectedOptions=${this.controller.filters.dpt}
           .expanded=${this.controller.expandedFilter === "dpt"}
           .narrow=${this.narrow}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11320,6 +11320,7 @@ __metadata:
     terser-webpack-plugin: "npm:5.6.1"
     tinykeys: "patch:tinykeys@npm%3A4.0.0#~/homeassistant-frontend/.yarn/patches/tinykeys-npm-4.0.0-a6ca3fd771.patch"
     ts-lit-plugin: "npm:2.0.2"
+    typedfastbitset: "npm:0.8.0"
     typescript: "npm:6.0.3"
     typescript-eslint: "npm:8.67.0"
     vite-tsconfig-paths: "npm:6.1.1"
@@ -15164,6 +15165,13 @@ __metadata:
     possible-typed-array-names: "npm:^1.0.0"
     reflect.getprototypeof: "npm:^1.0.6"
   checksum: 10/d6b2f0e81161682d2726eb92b1dc2b0890890f9930f33f9bcf6fc7272895ce66bc368066d273e6677776de167608adc53fcf81f1be39a146d64b630edbf2081c
+  languageName: node
+  linkType: hard
+
+"typedfastbitset@npm:0.8.0":
+  version: 0.8.0
+  resolution: "typedfastbitset@npm:0.8.0"
+  checksum: 10/b9e3344b66b195e2114fae3da88a9260d7a168f1248937cce49dede23ed4c94db47a5394693be0b07a532adfa85f921726c82f2c90cef4f4a7ba31772ff749de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR improves the Group Monitor filters by making the available options and their counts react to the current selection.

For users, values within the same filter are combined with OR, while different filter groups are combined with AND. Each option shows how many telegrams match together with the selections from the other filters. This makes it easier to narrow down the result without hiding useful alternatives.

Under the hood, telegrams are indexed by source, destination, direction, telegram type and DPT. The index is updated incrementally whenever the buffer changes. Filtering and counts are calculated from the same index state, which keeps the table and filter options in sync.

To keep this fast with larger telegram buffers, the index uses `typedfastbitset` (new external dep) for efficient set intersections instead of scanning all telegrams again for every filter option. In a benchmark on a M1 MacBook, processing 100,000 telegrams with 500,000 facet assignments took around 18 ms.